### PR TITLE
Adjust calibration process to use set points

### DIFF
--- a/bed-presence-mk1.yaml
+++ b/bed-presence-mk1.yaml
@@ -2,14 +2,13 @@ substitutions:
   name: bed-presence
   friendly_name: Bed Presence
 
-  # Auto Calibrate Trigger Percentile
-  # This controls how the trigger threshold is set when auto calibration is enabled. This is the percentage of the
-  # observed pressure that is required to register the bed as occupied. During auto calibration, the system stores the
-  # minimum and maximum pressures that it sees and used those values in combination with the trigger_percentile to
-  # calculate the trigger threshold.
-  #     - 0.9    Less sensitive, requires 90% of the maximum measured pressure to trigger (Default)
-  #     - 0.50   Set trigger exactly in the middle of minimum and maximum measured pressures
-  #     - 0.20   More sensitive, likely to be triggered by partner
+  # Calibrate Trigger Percentile
+  # This controls how the trigger threshold is set during calibration. During calibration, the unoccupied and occupied
+  # pressure values are determined. This is the percentage of the difference between those values required to trigger
+  # the "occupied" state.
+  #     - 0.75   Less sensitive, requires 75% of the occupied pressure to trigger
+  #     - 0.50   Set trigger exactly in the middle of unoccupied and occupied pressures (Default)
+  #     - 0.25   More sensitive, likely to be triggered by partner
   trigger_percentile: '0.90'
 
 esphome:
@@ -18,7 +17,9 @@ esphome:
   name_add_mac_suffix: true
   project:
     name: ElevatedSensors.BedPresenceMk1
-    version: "2024.7.0"
+    version: "2024.7.1"
+    release_summary: ""
+    release_url: ""
 
 esp32:
   board: esp32-c3-devkitm-1

--- a/bed-presence-mk1.yaml
+++ b/bed-presence-mk1.yaml
@@ -9,7 +9,7 @@ substitutions:
   #     - 0.75   Less sensitive, requires 75% of the occupied pressure to trigger
   #     - 0.50   Set trigger exactly in the middle of unoccupied and occupied pressures (Default)
   #     - 0.25   More sensitive, likely to be triggered by partner
-  trigger_percentile: '0.90'
+  trigger_percentile: '0.50'
 
 esphome:
   name: ${name}

--- a/bed-presence-mk1.yaml
+++ b/bed-presence-mk1.yaml
@@ -18,8 +18,6 @@ esphome:
   project:
     name: ElevatedSensors.BedPresenceMk1
     version: "2024.7.1"
-    release_summary: ""
-    release_url: ""
 
 esp32:
   board: esp32-c3-devkitm-1

--- a/bed-presence-mk1/base.yaml
+++ b/bed-presence-mk1/base.yaml
@@ -5,7 +5,7 @@ packages:
       sensor_name: Left
       sensor_id: left
       sensor_gpio: GPIO10
-  
+
   right_bed_sensor: !include
     file: sensor.yaml
     vars:
@@ -33,3 +33,4 @@ button:
 - platform: restart
   name: Restart
   id: bed_presence_restart
+  entity_category: diagnostic

--- a/bed-presence-mk1/base.yaml
+++ b/bed-presence-mk1/base.yaml
@@ -5,6 +5,7 @@ packages:
       sensor_name: Left
       sensor_id: left
       sensor_gpio: GPIO10
+
   right_bed_sensor: !include
     file: sensor.yaml
     vars:

--- a/bed-presence-mk1/base.yaml
+++ b/bed-presence-mk1/base.yaml
@@ -5,7 +5,6 @@ packages:
       sensor_name: Left
       sensor_id: left
       sensor_gpio: GPIO10
-
   right_bed_sensor: !include
     file: sensor.yaml
     vars:
@@ -33,4 +32,4 @@ button:
 - platform: restart
   name: Restart
   id: bed_presence_restart
-  entity_category: diagnostic
+  entity_category: "diagnostic"

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -45,19 +45,19 @@ sensor:
   - or:
     - delta: 0.1                  # only send if sensor changes by +/-0.1% (eliminate sensor noise)
     - throttle: 60s               # but still update every minute
-  on_value:
-    then:
-    - lambda: |-  # Update min/max measured pressures
-        if (x > id(val_max_${sensor_id}).state) {
-            auto call = id(val_max_${sensor_id}).make_call();
-            call.set_value(x);
-            call.perform();
-        }
-        if (x < id(val_min_${sensor_id}).state) {
-            auto call = id(val_min_${sensor_id}).make_call();
-            call.set_value(x);
-            call.perform();
-        }
+  # on_value:
+  #   then:
+  #   - lambda: |-  # Update min/max measured pressures
+  #       if (x > id(val_max_${sensor_id}).state) {
+  #           auto call = id(val_max_${sensor_id}).make_call();
+  #           call.set_value(x);
+  #           call.perform();
+  #       }
+  #       if (x < id(val_min_${sensor_id}).state) {
+  #           auto call = id(val_min_${sensor_id}).make_call();
+  #           call.set_value(x);
+  #           call.perform();
+  #       }
 
 - platform: template
   name: ${sensor_name} Pressure (Unoccupied)

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -59,18 +59,18 @@ sensor:
   #           call.perform();
   #       }
 
-- platform: template
-  name: ${sensor_name} Pressure (Unoccupied)
-  id: val_unoccupied_status_${sensor_id}
-  icon: mdi:gauge-empty
-  unit_of_measurement: '%'
-  entity_category: diagnostic
-- platform: template
-  name: ${sensor_name} Pressure (Occupied)
-  id: val_occupied_status_${sensor_id}
-  icon: mdi:gauge-full
-  unit_of_measurement: '%'
-  entity_category: diagnostic
+# - platform: template
+#   name: ${sensor_name} Pressure (Unoccupied)
+#   id: val_unoccupied_status_${sensor_id}
+#   icon: mdi:gauge-empty
+#   unit_of_measurement: '%'
+#   entity_category: diagnostic
+# - platform: template
+#   name: ${sensor_name} Pressure (Occupied)
+#   id: val_occupied_status_${sensor_id}
+#   icon: mdi:gauge-full
+#   unit_of_measurement: '%'
+#   entity_category: diagnostic
 # - platform: template
 #   name: ${sensor_name} Pressure (Min)
 #   id: val_min_status_${sensor_id}
@@ -86,7 +86,11 @@ sensor:
 
 number:
 - platform: template
+  name: ${sensor_name} Pressure (Unoccupied)
   id: val_unoccupied_${sensor_id}
+  icon: mdi:gauge-empty
+  unit_of_measurement: '%'
+  entity_category: diagnostic
   optimistic: true
   restore_value: true
   initial_value: 0
@@ -96,10 +100,14 @@ number:
   on_value:
     then:
     - lambda: |-  # Update status and trigger
-        id(val_unoccupied_status_${sensor_id}).publish_state(x);
+        # id(val_unoccupied_status_${sensor_id}).publish_state(x);
         id(update_trigger_${sensor_id})->execute();
 - platform: template
+  name: ${sensor_name} Pressure (Occupied)
   id: val_occupied_${sensor_id}
+  icon: mdi:gauge-full
+  unit_of_measurement: '%'
+  entity_category: diagnostic
   optimistic: true
   restore_value: true
   initial_value: 100
@@ -109,7 +117,7 @@ number:
   on_value:
     then:
     - lambda: |-  # Update status and trigger
-        id(val_occupied_status_${sensor_id}).publish_state(x);
+        # id(val_occupied_status_${sensor_id}).publish_state(x);
         id(update_trigger_${sensor_id})->execute();
 # - platform: template
 #   id: val_min_${sensor_id}

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -164,7 +164,7 @@ button:
     then:
     - number.set:
         id: val_unoccupied_${sensor_id}
-        value: !lambda return id(bed_sensor_${sensor_id}.state)
+        value: !lambda return id(bed_sensor_${sensor_id}).state
 - platform: template
   name: Calibrate ${sensor_name} Occupied
   id: calibration_${sensor_id}_set_occupied
@@ -174,7 +174,7 @@ button:
     then:
     - number.set:
         id: val_occupied_${sensor_id}
-        value: !lambda return id(bed_sensor_${sensor_id}.state)
+        value: !lambda return id(bed_sensor_${sensor_id}).state
 # - platform: template
 #   name: Calibration ${sensor_name} (Reset)
 #   id: calibration_${sensor_id}_reset

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -100,7 +100,7 @@ number:
   on_value:
     then:
     - lambda: |-  # Update status and trigger
-        # id(val_unoccupied_status_${sensor_id}).publish_state(x);
+        // id(val_unoccupied_status_${sensor_id}).publish_state(x);
         id(update_trigger_${sensor_id})->execute();
 - platform: template
   name: ${sensor_name} Pressure (Occupied)
@@ -117,7 +117,7 @@ number:
   on_value:
     then:
     - lambda: |-  # Update status and trigger
-        # id(val_occupied_status_${sensor_id}).publish_state(x);
+        // id(val_occupied_status_${sensor_id}).publish_state(x);
         id(update_trigger_${sensor_id})->execute();
 # - platform: template
 #   id: val_min_${sensor_id}

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -164,7 +164,7 @@ number:
 
 button:
 - platform: template
-  name: ${sensor_name} Unoccupied Calibrate
+  name: Calibrate ${sensor_name} Unoccupied
   id: calibration_${sensor_id}_set_unoccupied
   icon: mdi:bed-empty
   entity_category: config
@@ -174,7 +174,7 @@ button:
         id: val_unoccupied_${sensor_id}
         value: !lambda return id(bed_sensor_${sensor_id}).state;
 - platform: template
-  name: ${sensor_name} Occupied Calibrate
+  name: Calibrate ${sensor_name} Occupied
   id: calibration_${sensor_id}_set_occupied
   icon: mdi:bed
   entity_category: config

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -164,7 +164,7 @@ button:
     then:
     - number.set:
         id: val_unoccupied_${sensor_id}
-        value: float(bed_sensor_${sensor_id}.state)
+        value: bed_sensor_${sensor_id}.state
 - platform: template
   name: Calibrate ${sensor_name} Occupied
   id: calibration_${sensor_id}_set_occupied
@@ -174,7 +174,7 @@ button:
     then:
     - number.set:
         id: val_occupied_${sensor_id}
-        value: float(bed_sensor_${sensor_id}.state)
+        value: bed_sensor_${sensor_id}.state
 # - platform: template
 #   name: Calibration ${sensor_name} (Reset)
 #   id: calibration_${sensor_id}_reset

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -164,7 +164,7 @@ button:
     then:
     - number.set:
         id: val_unoccupied_${sensor_id}
-        value: !lambda return id(bed_sensor_${sensor_id}).state
+        value: !lambda return id(bed_sensor_${sensor_id}).state;
 - platform: template
   name: Calibrate ${sensor_name} Occupied
   id: calibration_${sensor_id}_set_occupied
@@ -174,7 +174,7 @@ button:
     then:
     - number.set:
         id: val_occupied_${sensor_id}
-        value: !lambda return id(bed_sensor_${sensor_id}).state
+        value: !lambda return id(bed_sensor_${sensor_id}).state;
 # - platform: template
 #   name: Calibration ${sensor_name} (Reset)
 #   id: calibration_${sensor_id}_reset

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -164,7 +164,7 @@ button:
     then:
     - number.set:
         id: val_unoccupied_${sensor_id}
-        value: bed_sensor_${sensor_id}).state
+        value: float(bed_sensor_${sensor_id}).state)
 - platform: template
   name: Calibrate ${sensor_name} Occupied
   id: calibration_${sensor_id}_set_occupied
@@ -174,7 +174,7 @@ button:
     then:
     - number.set:
         id: val_occupied_${sensor_id}
-        value: bed_sensor_${sensor_id}).state
+        value: float(bed_sensor_${sensor_id}).state)
 # - platform: template
 #   name: Calibration ${sensor_name} (Reset)
 #   id: calibration_${sensor_id}_reset

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -164,7 +164,7 @@ button:
     then:
     - number.set:
         id: val_unoccupied_${sensor_id}
-        value: bed_sensor_${sensor_id}.state
+        value: !lambda id(bed_sensor_${sensor_id}.state)
 - platform: template
   name: Calibrate ${sensor_name} Occupied
   id: calibration_${sensor_id}_set_occupied
@@ -174,7 +174,7 @@ button:
     then:
     - number.set:
         id: val_occupied_${sensor_id}
-        value: bed_sensor_${sensor_id}.state
+        value: !lambda id(bed_sensor_${sensor_id}.state)
 # - platform: template
 #   name: Calibration ${sensor_name} (Reset)
 #   id: calibration_${sensor_id}_reset

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -164,7 +164,7 @@ button:
     then:
     - number.set:
         id: val_unoccupied_${sensor_id}
-        value: !lambda id(bed_sensor_${sensor_id}.state)
+        value: !lambda return id(bed_sensor_${sensor_id}.state)
 - platform: template
   name: Calibrate ${sensor_name} Occupied
   id: calibration_${sensor_id}_set_occupied
@@ -174,7 +174,7 @@ button:
     then:
     - number.set:
         id: val_occupied_${sensor_id}
-        value: !lambda id(bed_sensor_${sensor_id}.state)
+        value: !lambda return id(bed_sensor_${sensor_id}.state)
 # - platform: template
 #   name: Calibration ${sensor_name} (Reset)
 #   id: calibration_${sensor_id}_reset

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -60,36 +60,33 @@ sensor:
         }
 
 - platform: template
-  name: ${sensor_name} Pressure (Min)
-  id: val_min_status_${sensor_id}
+  name: ${sensor_name} Pressure (Unoccupied)
+  id: val_unoccupied_status_${sensor_id}
   icon: mdi:gauge-empty
   unit_of_measurement: '%'
   entity_category: diagnostic
 - platform: template
-  name: ${sensor_name} Pressure (Max)
-  id: val_max_status_${sensor_id}
+  name: ${sensor_name} Pressure (Occupied)
+  id: val_occupied_status_${sensor_id}
   icon: mdi:gauge-full
   unit_of_measurement: '%'
   entity_category: diagnostic
+# - platform: template
+#   name: ${sensor_name} Pressure (Min)
+#   id: val_min_status_${sensor_id}
+#   icon: mdi:gauge-empty
+#   unit_of_measurement: '%'
+#   entity_category: diagnostic
+# - platform: template
+#   name: ${sensor_name} Pressure (Max)
+#   id: val_max_status_${sensor_id}
+#   icon: mdi:gauge-full
+#   unit_of_measurement: '%'
+#   entity_category: diagnostic
 
 number:
 - platform: template
-  id: val_min_${sensor_id}
-  optimistic: true
-  restore_value: true
-  initial_value: 100
-  min_value: 0
-  max_value: 100
-  step: 0.1
-  on_value:
-    then:
-    - lambda: |-  # Update status and trigger (if auto calibrating)
-        id(val_min_status_${sensor_id}).publish_state(x);
-        if (id(calibrate_auto_${sensor_id}).state) {
-          id(update_trigger_${sensor_id})->execute();
-        }
-- platform: template
-  id: val_max_${sensor_id}
+  id: val_unoccupied_${sensor_id}
   optimistic: true
   restore_value: true
   initial_value: 0
@@ -98,11 +95,52 @@ number:
   step: 0.1
   on_value:
     then:
-    - lambda: |-  # Update status and trigger (if auto calibrating)
-        id(val_max_status_${sensor_id}).publish_state(x);
-        if (id(calibrate_auto_${sensor_id}).state) {
-          id(update_trigger_${sensor_id})->execute();
-        }
+    - lambda: |-  # Update status and trigger
+        id(val_unoccupied_status_${sensor_id}).publish_state(x);
+        id(update_trigger_${sensor_id})->execute();
+- platform: template
+  id: val_occupied_${sensor_id}
+  optimistic: true
+  restore_value: true
+  initial_value: 100
+  min_value: 0
+  max_value: 100
+  step: 0.1
+  on_value:
+    then:
+    - lambda: |-  # Update status and trigger
+        id(val_occupied_status_${sensor_id}).publish_state(x);
+        id(update_trigger_${sensor_id})->execute();
+# - platform: template
+#   id: val_min_${sensor_id}
+#   optimistic: true
+#   restore_value: true
+#   initial_value: 100
+#   min_value: 0
+#   max_value: 100
+#   step: 0.1
+#   on_value:
+#     then:
+#     - lambda: |-  # Update status and trigger (if auto calibrating)
+#         id(val_min_status_${sensor_id}).publish_state(x);
+#         if (id(calibrate_auto_${sensor_id}).state) {
+#           id(update_trigger_${sensor_id})->execute();
+#         }
+# - platform: template
+#   id: val_max_${sensor_id}
+#   optimistic: true
+#   restore_value: true
+#   initial_value: 0
+#   min_value: 0
+#   max_value: 100
+#   step: 0.1
+#   on_value:
+#     then:
+#     - lambda: |-  # Update status and trigger (if auto calibrating)
+#         id(val_max_status_${sensor_id}).publish_state(x);
+#         if (id(calibrate_auto_${sensor_id}).state) {
+#           id(update_trigger_${sensor_id})->execute();
+#         }
 - platform: template
   name: ${sensor_name} Trigger Pressure
   id: val_trigger_${sensor_id}
@@ -118,49 +156,68 @@ number:
 
 button:
 - platform: template
-  name: Calibration ${sensor_name} (Reset)
-  id: calibration_${sensor_id}_reset
-  icon: mdi:sync
+  name: Calibrate ${sensor_name} Unoccupied
+  id: calibration_${sensor_id}_set_unoccupied
+  icon: mdi:bed-empty
   entity_category: config
   on_press:
     then:
     - number.set:
-        id: val_min_${sensor_id}
-        value: 100
-    - number.set:
-        id: val_max_${sensor_id}
-        value: 0
-    - number.set:
-        id: val_trigger_${sensor_id}
-        value: 50
-
-switch:
+        id: val_unoccupied_${sensor_id}
+        value: bed_sensor_${sensor_id}).state
 - platform: template
-  name: Calibration ${sensor_name} (Auto)
-  id: calibrate_auto_${sensor_id}
-  optimistic: true
-  icon: mdi:auto-fix
-  restore_mode: ALWAYS_OFF
-  turn_on_action:
-  - button.press: calibration_${sensor_id}_reset
+  name: Calibrate ${sensor_name} Occupied
+  id: calibration_${sensor_id}_set_occupied
+  icon: mdi:bed
   entity_category: config
+  on_press:
+    then:
+    - number.set:
+        id: val_occupied_${sensor_id}
+        value: bed_sensor_${sensor_id}).state
+# - platform: template
+#   name: Calibration ${sensor_name} (Reset)
+#   id: calibration_${sensor_id}_reset
+#   icon: mdi:sync
+#   entity_category: config
+#   on_press:
+#     then:
+#     - number.set:
+#         id: val_min_${sensor_id}
+#         value: 100
+#     - number.set:
+#         id: val_max_${sensor_id}
+#         value: 0
+#     - number.set:
+#         id: val_trigger_${sensor_id}
+#         value: 50
+
+# switch:
+# - platform: template
+#   name: Calibration ${sensor_name} (Auto)
+#   id: calibrate_auto_${sensor_id}
+#   optimistic: true
+#   icon: mdi:auto-fix
+#   restore_mode: ALWAYS_OFF
+#   turn_on_action:
+#   - button.press: calibration_${sensor_id}_reset
+#   entity_category: config
 
 script:
 - id: update_trigger_${sensor_id}
   mode: queued
   then:
   - lambda: |-  # Set trigger to x% of difference between min/max
-      float min_pressure = id(val_min_${sensor_id}).state;
-      float max_pressure = id(val_max_${sensor_id}).state;
-      if (min_pressure <= max_pressure) {
-          // calculate new trigger value
-          float trigger_pressure = min_pressure + ((max_pressure - min_pressure) * float(${trigger_percentile}));
+      float unoccupied_pressure = id(val_unoccupied_${sensor_id}).state;
+      float occupied_pressure = id(val_occupied_${sensor_id}).state;
 
-          // round to 2 decimal places
-          trigger_pressure = round(trigger_pressure * 100)/100.0;
+      // calculate new trigger value
+      float trigger_pressure = unoccupied_pressure + ((occupied_pressure - unoccupied_pressure) * float(${trigger_percentile}));
 
-          // set value
-          auto call = id(val_trigger_${sensor_id}).make_call();
-          call.set_value(trigger_pressure);
-          call.perform();
-      }
+      // round to 2 decimal places
+      trigger_pressure = round(trigger_pressure * 100)/100.0;
+
+      // set value
+      auto call = id(val_trigger_${sensor_id}).make_call();
+      call.set_value(trigger_pressure);
+      call.perform();

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -164,7 +164,7 @@ number:
 
 button:
 - platform: template
-  name: Calibrate ${sensor_name} Unoccupied
+  name: ${sensor_name} Unoccupied Calibrate
   id: calibration_${sensor_id}_set_unoccupied
   icon: mdi:bed-empty
   entity_category: config
@@ -174,7 +174,7 @@ button:
         id: val_unoccupied_${sensor_id}
         value: !lambda return id(bed_sensor_${sensor_id}).state;
 - platform: template
-  name: Calibrate ${sensor_name} Occupied
+  name: ${sensor_name} Occupied Calibrate
   id: calibration_${sensor_id}_set_occupied
   icon: mdi:bed
   entity_category: config

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -86,7 +86,7 @@ sensor:
 
 number:
 - platform: template
-  name: ${sensor_name} Pressure (Unoccupied)
+  name: ${sensor_name} Unoccupied Pressure
   id: val_unoccupied_${sensor_id}
   icon: mdi:gauge-empty
   unit_of_measurement: '%'
@@ -103,7 +103,7 @@ number:
         // id(val_unoccupied_status_${sensor_id}).publish_state(x);
         id(update_trigger_${sensor_id})->execute();
 - platform: template
-  name: ${sensor_name} Pressure (Occupied)
+  name: ${sensor_name} Occupied Pressure
   id: val_occupied_${sensor_id}
   icon: mdi:gauge-full
   unit_of_measurement: '%'

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -164,7 +164,7 @@ button:
     then:
     - number.set:
         id: val_unoccupied_${sensor_id}
-        value: float(bed_sensor_${sensor_id}).state)
+        value: float(bed_sensor_${sensor_id}.state)
 - platform: template
   name: Calibrate ${sensor_name} Occupied
   id: calibration_${sensor_id}_set_occupied
@@ -174,7 +174,7 @@ button:
     then:
     - number.set:
         id: val_occupied_${sensor_id}
-        value: float(bed_sensor_${sensor_id}).state)
+        value: float(bed_sensor_${sensor_id}.state)
 # - platform: template
 #   name: Calibration ${sensor_name} (Reset)
 #   id: calibration_${sensor_id}_reset

--- a/static/bed-presence-mk1/getting-started.md
+++ b/static/bed-presence-mk1/getting-started.md
@@ -70,13 +70,12 @@ Welcome to Bed Presence for ESPHome! This page contains everything you need to g
 
 ## Automatic Sensor Calibration
 
-1. The calibration process requires you to get into and out of your bed. It uses the maximum and minimum observed pressures to automatically figure out the best trigger pressure.
-2. Have the person you are calibrating for lay on their side of the bed.
-3. Navigate to the device and find the "Configuration" section.
-4. Turn on "Calibration \[Right or Left\] (Auto)".
-5. Have the person get out of bed.
-6. Turn off "Calibration \[Right or Left\] (Auto)".
+1. The calibration process requires you to get into and our of your bed. It records the sensor readings while the bed is both occupied and unoccupied and automatically calculates the best trigger pressure. This process is best performed when the bed has settled in the unoccupied state. For some beds, this is instant. For others, the unoccupied pressure may increase slowly over several hours. NOTE: you can always go back and update the unoccupied pressure at a later time when it's more convenient (e.g. you're at work and the bed has been unoccupied for several hours).
+2. Navigate to the device under Home Assistant Devices. Find the "Configuration" section.
+3. Press "Calibrate Unoccupied" for the desired side of the bed.
+4. Have the person you are calibrating for gently lay on their side of the bed.
+5. Let the sensor settle for a few seconds and press "Calibrate Occupied" for the desired side of the bed.
 
 ## Manual Sensor Calibration
-1. Alternatively, you can manually set the "Trigger Pressure". The Max/Min Pressure values in the "Diagnostic" section can help guide your desired pressure.
+1. Alternatively, you can manually set the "Trigger Pressure". Viewing the graph of the sensor pressure can help guide your desired pressure.
 2. If using only once sensor, you can set the value slightly higher than the "non occupied" pressure. If using both sensors, make sure to set it high enough that someone on the opposite side of the bed doesn't trigger it.


### PR DESCRIPTION
Per feedback, the calibration process needed some tweaking to be reliable across different beds. The resulting trigger value was often high. I think using set points removes some of the variability, and allows us to set it a little lower.