### PR TITLE
Add derived sensors for bed occupied_both, bed_occupied_either and average_pressure

### DIFF
--- a/bed-presence-mk1/base.yaml
+++ b/bed-presence-mk1/base.yaml
@@ -29,6 +29,45 @@ sensor:
   entity_category: "diagnostic"
   device_class: ""
 
+- platform: template
+  name: Average Pressure (Current)
+  id: bed_sensor_average
+  update_interval: 0.5s
+  unit_of_measurement: '%'
+  icon: mdi:gauge
+  lambda: return (id(bed_sensor_left).state + id(bed_sensor_right).state) / 2.0;
+
+binary_sensor:
+- platform: template
+  name: Bed Occupied (Both, Fast)
+  id: bed_occupied_both_fast
+  device_class: occupancy
+  icon: mdi:bed
+  disabled_by_default: true
+  lambda: return id(bed_occupied_left_fast).state && id(bed_occupied_right_fast).state;
+
+- platform: template
+  name: Bed Occupied (Either, Fast)
+  id: bed_occupied_either_fast
+  device_class: occupancy
+  icon: mdi:bed
+  disabled_by_default: true
+  lambda: return id(bed_occupied_left_fast).state || id(bed_occupied_right_fast).state;
+
+- platform: template
+  name: Bed Occupied (Both)
+  id: bed_occupied_both
+  device_class: occupancy
+  icon: mdi:bed
+  lambda: return id(bed_occupied_left).state && id(bed_occupied_right).state;
+
+- platform: template
+  name: Bed Occupied (Either)
+  id: bed_occupied_either
+  device_class: occupancy
+  icon: mdi:bed
+  lambda: return id(bed_occupied_left).state || id(bed_occupied_right).state;
+
 button:
 - platform: restart
   name: Restart

--- a/bed-presence-mk1/base.yaml
+++ b/bed-presence-mk1/base.yaml
@@ -29,14 +29,6 @@ sensor:
   entity_category: "diagnostic"
   device_class: ""
 
-- platform: template
-  name: Average Pressure (Current)
-  id: bed_sensor_average
-  update_interval: 0.5s
-  unit_of_measurement: '%'
-  icon: mdi:gauge
-  lambda: return (id(bed_sensor_left).state + id(bed_sensor_right).state) / 2.0;
-
 binary_sensor:
 - platform: template
   name: Bed Occupied (Both, Fast)


### PR DESCRIPTION
I intentionally added both a fast and normal variant for the bed_occupied_both/either sensors so that if users need the fast ones they can enable them.