### PR TITLE
Slim down bed-presence-mk1.factory.yaml

### DIFF
--- a/.github/workflows/workflow-ci.yml
+++ b/.github/workflows/workflow-ci.yml
@@ -17,4 +17,4 @@ jobs:
       - name: Build ESPHome firmware to verify configuration
         uses: esphome/build-action@v4.0.1
         with:
-          yaml_file: ${{ matrix.file }}
+          yaml-file: ${{ matrix.file }}

--- a/bed-presence-mk1.factory.yaml
+++ b/bed-presence-mk1.factory.yaml
@@ -1,17 +1,17 @@
 packages:
   bed-presence-mk1: !include bed-presence-mk1.yaml
-  
+
 esphome:
   project:
     name: ElevatedSensors.BedPresenceMk1
-    version: "2024.8.5"
+    version: "2024.8.6"
 
 # Allow Import
 dashboard_import:
   package_import_url: github://ElevatedSensors/sensor-configs/bed-presence-mk1.yaml@main
   import_full_config: true
 
-# Managed updates from Elevated Sensors (future)
+# Managed updates from Elevated Sensors
 ota:
   - platform: http_request
     id: ota_http_request
@@ -25,3 +25,11 @@ update:
 
 http_request:
   verify_ssl: true
+
+# Allow provisioning Wi-Fi via serial
+improv_serial:
+
+# Sets up Bluetooth LE to allow the user
+# to provision wifi credentials to the device.
+esp32_improv:
+  authorizer: none

--- a/bed-presence-mk1.factory.yaml
+++ b/bed-presence-mk1.factory.yaml
@@ -1,72 +1,15 @@
-substitutions:
-  name: bed-presence
-  friendly_name: Bed Presence
-
-  # Calibrate Trigger Percentile
-  # This controls how the trigger threshold is set during calibration. During calibration, the unoccupied and occupied
-  # pressure values are determined. This is the percentage of the difference between those values required to trigger
-  # the "occupied" state.
-  #     - 0.75   Requires 75% of the occupied pressure to trigger (Default)
-  #     - 0.50   Set trigger exactly in the middle of unoccupied and occupied pressures
-  #     - 0.25   More sensitive, likely to be triggered by partner
-  trigger_percentile: '0.75'
-
-  # Fast Sensor Delay
-  # This controls how long the "Fast" sensor must register its value before updating. Without any delay, the sensor
-  # will register frequent fall negatives as you shift in bed.
-  #     - 2s    Same response as standard sensor
-  #     - 500ms Good starting point for getting speed without too many false negatives (Default)
-  #     - 0ms   No delay, expect frequent false negatives
-  fast_delayed_off: '500ms'
-
+packages:
+  bed-presence-mk1: !include bed-presence-mk1.yaml
+  
 esphome:
-  name: ${name}
-  friendly_name: ${friendly_name}
-  name_add_mac_suffix: true
   project:
     name: ElevatedSensors.BedPresenceMk1
     version: "2024.8.5"
-  platformio_options:
-    board_build.flash_mode: dio # dio flash_mode fixes issue where board bootloops using esp-idf
-
-esp32:
-  board: esp32-c3-devkitm-1
-  framework:
-    type: esp-idf # using arduino causes board to reset multiple times/day
 
 # Allow Import
 dashboard_import:
   package_import_url: github://ElevatedSensors/sensor-configs/bed-presence-mk1.yaml@main
   import_full_config: true
-
-# Enable logging
-logger:
-
-# Enable Home Assistant API
-api:
-
-# Allow provisioning Wi-Fi via serial
-improv_serial:
-
-wifi:
-  # Set up a wifi access point
-  ap: {}
-
-# In combination with the `ap` this allows the user
-# to provision wifi credentials to the device via WiFi AP.
-captive_portal:
-
-# Sets up Bluetooth LE (Only on ESP32) to allow the user
-# to provision wifi credentials to the device.
-esp32_improv:
-  authorizer: none
-
-# To have a "next url" for improv serial
-web_server:
-
-# # Enable esphome OTA updates
-# ota:
-#   platform: esphome
 
 # Managed updates from Elevated Sensors (future)
 ota:
@@ -82,11 +25,3 @@ update:
 
 http_request:
   verify_ssl: true
-
-################################################################################
-packages:
-  remote_package:
-    url: https://github.com/ElevatedSensors/sensor-configs
-    ref: main
-    files: ['bed-presence-mk1/base.yaml']
-    refresh: 1s

--- a/bed-presence-mk1.yaml
+++ b/bed-presence-mk1.yaml
@@ -34,19 +34,11 @@ esp32:
   framework:
     type: esp-idf # using arduino causes board to reset multiple times/day
 
-# # Allow Import
-# dashboard_import:
-#   package_import_url: github://ElevatedSensors/sensor-configs/bed-presence-mk1.yaml@main
-#   import_full_config: true
-
 # Enable logging
 logger:
 
 # Enable Home Assistant API
 api:
-
-# Allow provisioning Wi-Fi via serial
-improv_serial:
 
 wifi:
   # Set up a wifi access point
@@ -56,32 +48,12 @@ wifi:
 # to provision wifi credentials to the device via WiFi AP.
 captive_portal:
 
-# Sets up Bluetooth LE (Only on ESP32) to allow the user
-# to provision wifi credentials to the device.
-esp32_improv:
-  authorizer: none
-
 # To have a "next url" for improv serial
 web_server:
 
 # Enable esphome OTA updates
 ota:
   platform: esphome
-
-# # Managed updates from Elevated Sensors (future)
-# ota:
-#   - platform: http_request
-#     id: ota_http_request
-
-# update:
-#   - platform: http_request
-#     id: update_http_request
-#     name: Firmware
-#     source: https://docs.elevatedsensors.com/bpmk1-manifest.json
-#     update_interval: 10s   # TODO update to 6 hours after dev work
-
-# http_request:
-#   verify_ssl: true
 
 ################################################################################
 packages:


### PR DESCRIPTION
The factory file only really needs the project info, http_request and dashboard import configs. 

(You can move other stuff here that would not normally be needed once a device is adopted like `esp32_improv` / `improv_serial`)