### PR TITLE
Bed Presence Mk1 - 2024.10.0 Release

### DIFF
--- a/bed-presence-mk1.factory.yaml
+++ b/bed-presence-mk1.factory.yaml
@@ -4,7 +4,7 @@ packages:
 esphome:
   project:
     name: ElevatedSensors.BedPresenceMk1
-    version: 2024.9.0
+    version: 2024.10.0
 
 # Allow ESPHome Adoption
 dashboard_import:

--- a/bed-presence-mk1.yaml
+++ b/bed-presence-mk1.yaml
@@ -37,7 +37,8 @@ ota:
 packages:
   remote_package:
     url: https://github.com/ElevatedSensors/sensor-configs
-    ref: main
+    # ref: main
+    ref: dev-tune-delta
     files: ['bed-presence-mk1/base.yaml']
     refresh: 1s
 

--- a/bed-presence-mk1.yaml
+++ b/bed-presence-mk1.yaml
@@ -41,29 +41,10 @@ packages:
     files: ['bed-presence-mk1/base.yaml']
     refresh: 1s
 
-# Add substitutions to override package default settings
+# See https://github.com/ElevatedSensors/sensor-configs/bed-presence-mk1/sensor.yaml for substitution descriptions
 # substitutions:
-#   # Calibrate Trigger Percentile
-#   # This controls how the trigger threshold is set during calibration. During calibration, the unoccupied and occupied
-#   # pressure values are determined. This is the percentage of the difference between those values required to trigger
-#   # the "occupied" state.
-#   #     - 0.75  Requires 75% of the occupied pressure to trigger (Default)
-#   #     - 0.50   Set trigger exactly in the middle of unoccupied and occupied pressures
-#   #     - 0.25  More sensitive, likely to be triggered by partner
 #   trigger_percentile: '0.75'
-
-#   # Fast Sensor Delay
-#   # This controls how long the "Fast" sensor must register its value before updating. Without any delay, the sensor
-#   # will register frequent fall negatives as you shift in bed.
-#   #     - 2s    Same response as standard sensor
-#   #     - 500ms Good starting point for getting speed without too many false negatives (Default)
-#   #     - 0ms   No delay, expect frequent false negatives
 #   fast_delayed_off: '500ms'
-
-#   # Reporting Delta
-#   # The pressure % must change by this amount before it is reported (note the sensor updates every 60s regardless
-#   # of this delta).
-#   #     - 10.0  Only report very large changes
-#   #     - 1.0   Relatively sensitive with much less reporting (default)
-#   #     - 0.1   Very sensitive, will report frequently
+#   standard_delayed_on_off: '2s'
 #   reporting_delta: '1.0'
+#   reporting_duration_max: '60s'

--- a/bed-presence-mk1.yaml
+++ b/bed-presence-mk1.yaml
@@ -41,11 +41,11 @@ packages:
     files: ['bed-presence-mk1/base.yaml']
     refresh: 1s
 
-#See https://github.com/ElevatedSensors/sensor-configs/bed-presence-mk1/sensor.yaml for substitution descriptions
-#substitutions:
-#  trigger_percentile: '0.75'
-#  fast_delayed_off: '500ms'
-#  standard_delayed_on_off: '2s'
-#  reporting_delta: '1.0'
-#  reporting_duration_max: '180s'
-#  averaging_window_samples: '1'
+# See https://github.com/ElevatedSensors/sensor-configs/bed-presence-mk1/sensor.yaml for substitution descriptions
+# substitutions:
+#   trigger_percentile: '0.75'
+#   fast_delayed_off: '500ms'
+#   standard_delayed_on_off: '2s'
+#   reporting_delta: '1.0'
+#   reporting_duration_max: '180s'
+#   averaging_window_samples: '1'

--- a/bed-presence-mk1.yaml
+++ b/bed-presence-mk1.yaml
@@ -37,7 +37,7 @@ ota:
 packages:
   remote_package:
     url: https://github.com/ElevatedSensors/sensor-configs
-    ref: dev-tune-delta
+    ref: main
     files: ['bed-presence-mk1/base.yaml']
     refresh: 1s
 

--- a/bed-presence-mk1.yaml
+++ b/bed-presence-mk1.yaml
@@ -5,7 +5,7 @@ esphome:
   name_add_mac_suffix: true
   project:
     name: ElevatedSensors.BedPresenceMk1
-    version: "DIY"
+    version: DIY
   platformio_options:
     board_build.flash_mode: dio
 

--- a/bed-presence-mk1.yaml
+++ b/bed-presence-mk1.yaml
@@ -6,7 +6,7 @@ substitutions:
   #     - 0.75  Requires 75% of the occupied pressure to trigger (Default)
   #     - 0.50   Set trigger exactly in the middle of unoccupied and occupied pressures
   #     - 0.25  More sensitive, likely to be triggered by partner
-  trigger_percentile: '0.75'
+  # trigger_percentile: '0.75'
 
   # Fast Sensor Delay
   # This controls how long the "Fast" sensor must register its value before updating. Without any delay, the sensor
@@ -14,7 +14,15 @@ substitutions:
   #     - 2s    Same response as standard sensor
   #     - 500ms Good starting point for getting speed without too many false negatives (Default)
   #     - 0ms   No delay, expect frequent false negatives
-  fast_delayed_off: '500ms'
+  # fast_delayed_off: '500ms'
+  #
+  # Reporting Delta
+  # The pressure % must change by this amount before it is reported (note the sensor updates every 60s regardless
+  # of this delta).
+  #     - 10.0  Only report very large changes
+  #     - 1.0   Relatively sensitive with much less reporting (default)
+  #     - 0.1   Very sensitive, will report frequently
+  # reporting_delta: 1.0
 
 esphome:
   name: bed-presence
@@ -25,12 +33,12 @@ esphome:
     name: ElevatedSensors.BedPresenceMk1
     version: "DIY"
   platformio_options:
-    board_build.flash_mode: dio # dio flash_mode fixes issue where board bootloops using esp-idf
+    board_build.flash_mode: dio
 
 esp32:
   board: esp32-c3-devkitm-1
   framework:
-    type: esp-idf # using arduino causes board to reset multiple times/day
+    type: esp-idf
 
 # Enable logging
 logger:

--- a/bed-presence-mk1.yaml
+++ b/bed-presence-mk1.yaml
@@ -1,29 +1,3 @@
-substitutions:
-  # Calibrate Trigger Percentile
-  # This controls how the trigger threshold is set during calibration. During calibration, the unoccupied and occupied
-  # pressure values are determined. This is the percentage of the difference between those values required to trigger
-  # the "occupied" state.
-  #     - 0.75  Requires 75% of the occupied pressure to trigger (Default)
-  #     - 0.50   Set trigger exactly in the middle of unoccupied and occupied pressures
-  #     - 0.25  More sensitive, likely to be triggered by partner
-  # trigger_percentile: '0.75'
-
-  # Fast Sensor Delay
-  # This controls how long the "Fast" sensor must register its value before updating. Without any delay, the sensor
-  # will register frequent fall negatives as you shift in bed.
-  #     - 2s    Same response as standard sensor
-  #     - 500ms Good starting point for getting speed without too many false negatives (Default)
-  #     - 0ms   No delay, expect frequent false negatives
-  # fast_delayed_off: '500ms'
-  #
-  # Reporting Delta
-  # The pressure % must change by this amount before it is reported (note the sensor updates every 60s regardless
-  # of this delta).
-  #     - 10.0  Only report very large changes
-  #     - 1.0   Relatively sensitive with much less reporting (default)
-  #     - 0.1   Very sensitive, will report frequently
-  # reporting_delta: 1.0
-
 esphome:
   name: bed-presence
   friendly_name: Bed Presence
@@ -66,3 +40,30 @@ packages:
     ref: main
     files: ['bed-presence-mk1/base.yaml']
     refresh: 1s
+
+# Add substitutions to override package default settings
+# substitutions:
+#   # Calibrate Trigger Percentile
+#   # This controls how the trigger threshold is set during calibration. During calibration, the unoccupied and occupied
+#   # pressure values are determined. This is the percentage of the difference between those values required to trigger
+#   # the "occupied" state.
+#   #     - 0.75  Requires 75% of the occupied pressure to trigger (Default)
+#   #     - 0.50   Set trigger exactly in the middle of unoccupied and occupied pressures
+#   #     - 0.25  More sensitive, likely to be triggered by partner
+#   trigger_percentile: '0.75'
+
+#   # Fast Sensor Delay
+#   # This controls how long the "Fast" sensor must register its value before updating. Without any delay, the sensor
+#   # will register frequent fall negatives as you shift in bed.
+#   #     - 2s    Same response as standard sensor
+#   #     - 500ms Good starting point for getting speed without too many false negatives (Default)
+#   #     - 0ms   No delay, expect frequent false negatives
+#   fast_delayed_off: '500ms'
+
+#   # Reporting Delta
+#   # The pressure % must change by this amount before it is reported (note the sensor updates every 60s regardless
+#   # of this delta).
+#   #     - 10.0  Only report very large changes
+#   #     - 1.0   Relatively sensitive with much less reporting (default)
+#   #     - 0.1   Very sensitive, will report frequently
+#   reporting_delta: '1.0'

--- a/bed-presence-mk1.yaml
+++ b/bed-presence-mk1.yaml
@@ -45,10 +45,12 @@ packages:
 # See https://github.com/ElevatedSensors/sensor-configs/bed-presence-mk1/sensor.yaml for substitution descriptions
 # substitutions:
 #   trigger_percentile: '0.75'
-#   fast_delayed_off: '500ms'
-#   standard_delayed_on_off: '2s'
+#   averaging_window_samples: '1'
+#   fast_delayed_on: '0ms'
+#   fast_delayed_off: '0ms'
+#   standard_delayed_on: '0s'
+#   standard_delayed_off: '1s'
 #   reporting_delta: '1.0'
 #   reporting_interval_max: '180s'
-#   averaging_window_samples: '1'
 #   calibrate_100: '408000'
 #   calibrate_0: '276000'

--- a/bed-presence-mk1.yaml
+++ b/bed-presence-mk1.yaml
@@ -37,8 +37,7 @@ ota:
 packages:
   remote_package:
     url: https://github.com/ElevatedSensors/sensor-configs
-    # ref: main
-    ref: dev-tune-delta
+    ref: main
     files: ['bed-presence-mk1/base.yaml']
     refresh: 1s
 

--- a/bed-presence-mk1.yaml
+++ b/bed-presence-mk1.yaml
@@ -41,10 +41,11 @@ packages:
     files: ['bed-presence-mk1/base.yaml']
     refresh: 1s
 
-# See https://github.com/ElevatedSensors/sensor-configs/bed-presence-mk1/sensor.yaml for substitution descriptions
-# substitutions:
-#   trigger_percentile: '0.75'
-#   fast_delayed_off: '500ms'
-#   standard_delayed_on_off: '2s'
-#   reporting_delta: '1.0'
-#   reporting_duration_max: '60s'
+#See https://github.com/ElevatedSensors/sensor-configs/bed-presence-mk1/sensor.yaml for substitution descriptions
+#substitutions:
+#  trigger_percentile: '0.75'
+#  fast_delayed_off: '500ms'
+#  standard_delayed_on_off: '2s'
+#  reporting_delta: '1.0'
+#  reporting_duration_max: '180s'
+#  averaging_window_samples: '1'

--- a/bed-presence-mk1.yaml
+++ b/bed-presence-mk1.yaml
@@ -44,7 +44,7 @@ packages:
 # See https://github.com/ElevatedSensors/sensor-configs/bed-presence-mk1/sensor.yaml for substitution descriptions
 # substitutions:
 #   trigger_percentile: '0.75'
-#   averaging_window_samples: '1'
+#   averaging_window_samples: '5'
 #   fast_delayed_on: '0ms'
 #   fast_delayed_off: '0ms'
 #   standard_delayed_on: '0s'

--- a/bed-presence-mk1.yaml
+++ b/bed-presence-mk1.yaml
@@ -37,7 +37,7 @@ ota:
 packages:
   remote_package:
     url: https://github.com/ElevatedSensors/sensor-configs
-    ref: main
+    ref: dev-tune-delta
     files: ['bed-presence-mk1/base.yaml']
     refresh: 1s
 

--- a/bed-presence-mk1.yaml
+++ b/bed-presence-mk1.yaml
@@ -41,7 +41,9 @@ packages:
     files: ['bed-presence-mk1/base.yaml']
     refresh: 1s
 
-# See https://github.com/ElevatedSensors/sensor-configs/bed-presence-mk1/sensor.yaml for substitution descriptions
+# See https://github.com/ElevatedSensors/sensor-configs/blob/main/bed-presence-mk1/sensor.yaml for a detailed
+# description of available substitutions.
+#
 # substitutions:
 #   trigger_percentile: '0.75'
 #   averaging_window_samples: '5'

--- a/bed-presence-mk1.yaml
+++ b/bed-presence-mk1.yaml
@@ -48,5 +48,7 @@ packages:
 #   fast_delayed_off: '500ms'
 #   standard_delayed_on_off: '2s'
 #   reporting_delta: '1.0'
-#   reporting_duration_max: '180s'
+#   reporting_interval_max: '180s'
 #   averaging_window_samples: '1'
+#   calibrate_100: '408000'
+#   calibrate_0: '276000'

--- a/bed-presence-mk1/base.yaml
+++ b/bed-presence-mk1/base.yaml
@@ -14,59 +14,59 @@ packages:
       sensor_gpio: GPIO20
 
 sensor:
-- platform: wifi_signal # Reports the WiFi signal strength in dB
-  name: WiFi Signal dB
-  id: wifi_signal_db
-  update_interval: 60s
+  - platform: wifi_signal   # Reports the WiFi signal strength in dB
+    name: WiFi Signal dB
+    id: wifi_signal_db
+    update_interval: 60s
 
-- platform: copy # Reports the WiFi signal strength in %
-  source_id: wifi_signal_db
-  name: "WiFi Signal Percent"
-  id: wifi_signal_percent
-  filters:
-    - lambda: return min(max(2 * (x + 100.0), 0.0), 100.0);
-  unit_of_measurement: "%"
-  entity_category: "diagnostic"
-  device_class: ""
+  - platform: copy          # Reports the WiFi signal strength in %
+    source_id: wifi_signal_db
+    name: "WiFi Signal Percent"
+    id: wifi_signal_percent
+    filters:
+      - lambda: return min(max(2 * (x + 100.0), 0.0), 100.0);
+    unit_of_measurement: "%"
+    entity_category: "diagnostic"
+    device_class: ""
 
-- platform: uptime
-  type: seconds
-  id: bed_presence_uptime
-  name: "Uptime"
+  - platform: uptime
+    type: seconds
+    id: bed_presence_uptime
+    name: "Uptime"
 
 binary_sensor:
-- platform: template
-  name: Bed Occupied Both (Fast)
-  id: bed_occupied_both_fast
-  device_class: occupancy
-  icon: mdi:bunk-bed
-  disabled_by_default: true
-  lambda: return id(bed_occupied_left_fast).state && id(bed_occupied_right_fast).state;
+  - platform: template
+    name: Bed Occupied Both (Fast)
+    id: bed_occupied_both_fast
+    device_class: occupancy
+    icon: mdi:bunk-bed
+    disabled_by_default: true
+    lambda: return id(bed_occupied_left_fast).state && id(bed_occupied_right_fast).state;
 
-- platform: template
-  name: Bed Occupied Either (Fast)
-  id: bed_occupied_either_fast
-  device_class: occupancy
-  icon: mdi:bunk-bed
-  disabled_by_default: true
-  lambda: return id(bed_occupied_left_fast).state || id(bed_occupied_right_fast).state;
+  - platform: template
+    name: Bed Occupied Either (Fast)
+    id: bed_occupied_either_fast
+    device_class: occupancy
+    icon: mdi:bunk-bed
+    disabled_by_default: true
+    lambda: return id(bed_occupied_left_fast).state || id(bed_occupied_right_fast).state;
 
-- platform: template
-  name: Bed Occupied Both
-  id: bed_occupied_both
-  device_class: occupancy
-  icon: mdi:bunk-bed
-  lambda: return id(bed_occupied_left).state && id(bed_occupied_right).state;
+  - platform: template
+    name: Bed Occupied Both
+    id: bed_occupied_both
+    device_class: occupancy
+    icon: mdi:bunk-bed
+    lambda: return id(bed_occupied_left).state && id(bed_occupied_right).state;
 
-- platform: template
-  name: Bed Occupied Either
-  id: bed_occupied_either
-  device_class: occupancy
-  icon: mdi:bunk-bed
-  lambda: return id(bed_occupied_left).state || id(bed_occupied_right).state;
+  - platform: template
+    name: Bed Occupied Either
+    id: bed_occupied_either
+    device_class: occupancy
+    icon: mdi:bunk-bed
+    lambda: return id(bed_occupied_left).state || id(bed_occupied_right).state;
 
 button:
-- platform: restart
-  name: Restart
-  id: btn_restart
-  entity_category: "diagnostic"
+  - platform: restart
+    name: Restart
+    id: btn_restart
+    entity_category: "diagnostic"

--- a/bed-presence-mk1/base.yaml
+++ b/bed-presence-mk1/base.yaml
@@ -65,6 +65,10 @@ binary_sensor:
     icon: mdi:bunk-bed
     lambda: return id(bed_occupied_left).state || id(bed_occupied_right).state;
 
+  - platform: status
+    id: bed_presence_status
+    name: Status
+
 button:
   - platform: restart
     name: Restart

--- a/bed-presence-mk1/base.yaml
+++ b/bed-presence-mk1/base.yaml
@@ -82,3 +82,4 @@ switch:
     optimistic: true
     restore_mode: RESTORE_DEFAULT_OFF
     entity_category: "config"
+    icon: mdi:arrow-expand-down

--- a/bed-presence-mk1/base.yaml
+++ b/bed-presence-mk1/base.yaml
@@ -74,3 +74,11 @@ button:
     name: Restart
     id: btn_restart
     entity_category: "diagnostic"
+
+switch:
+  - platform: template
+    name: Expand Range
+    id: expand_range
+    optimistic: true
+    restore_mode: RESTORE_DEFAULT_OFF
+    entity_category: "configuration"

--- a/bed-presence-mk1/base.yaml
+++ b/bed-presence-mk1/base.yaml
@@ -1,38 +1,3 @@
-# Override these values by including a substitutions section in the yaml config that imports this package
-substitutions:
-  # Calibrate Trigger Percentile
-  # This controls how the trigger threshold is set during calibration. During calibration, the unoccupied and occupied
-  # pressure values are determined. This is the percentage of the difference between those values required to trigger
-  # the "occupied" state.
-  #     - 0.75  Requires 75% of the occupied pressure to trigger (Default)
-  #     - 0.50   Set trigger exactly in the middle of unoccupied and occupied pressures
-  #     - 0.25  More sensitive, likely to be triggered by partner
-  trigger_percentile: '0.75'
-
-  # Fast Sensor Delay
-  # This controls how long the "Fast" sensor must register "unoccupied" before reporting. "occupied" is reported
-  # instantly. Without any delay, the sensor will register frequent false negatives as you shift in bed.
-  #     - 2s    Same response as standard sensor
-  #     - 500ms Good starting point for getting speed without too many false negatives (Default)
-  #     - 0ms   No delay, expect frequent false negatives
-  fast_delayed_off: '500ms'
-
-  # Standard Sensor Delay
-  # This controls how long the standard sensor must register "unoccupied" or "occupied" before reporting. This
-  # ensures stability and prevents shifting in bed from registering "unoccupied".
-  standard_delayed_on_off: '2s'
-
-  # Reporting Delta
-  # The sensor must change by this amount before an update is sent (or the reporting_duration_max has been hit)
-  #     - 10.0  Only report very large changes
-  #     - 1.0   Relatively sensitive with much less reporting (default)
-  #     - 0.1   Very sensitive, will report frequently
-  reporting_delta: '1.0'
-
-  # Reporting Duration (Max)
-  # The max amount of time between sensor reports (even if the value hasn't changed)
-  reporting_duration_max: '60s'
-
 packages:
   left_bed_sensor: !include
     file: sensor.yaml

--- a/bed-presence-mk1/base.yaml
+++ b/bed-presence-mk1/base.yaml
@@ -77,9 +77,9 @@ button:
 
 switch:
   - platform: template
-    name: Expand Range
-    id: expand_range
+    name: Full Range
+    id: full_range
     optimistic: true
     restore_mode: RESTORE_DEFAULT_OFF
     entity_category: "config"
-    icon: mdi:arrow-expand-down
+    icon: mdi:arrow-expand

--- a/bed-presence-mk1/base.yaml
+++ b/bed-presence-mk1/base.yaml
@@ -81,4 +81,4 @@ switch:
     id: expand_range
     optimistic: true
     restore_mode: RESTORE_DEFAULT_OFF
-    entity_category: "configuration"
+    entity_category: "config"

--- a/bed-presence-mk1/base.yaml
+++ b/bed-presence-mk1/base.yaml
@@ -21,18 +21,18 @@ sensor:
 
   - platform: copy          # Reports the WiFi signal strength in %
     source_id: wifi_signal_db
-    name: "WiFi Signal Percent"
+    name: WiFi Signal Percent
     id: wifi_signal_percent
     filters:
       - lambda: return min(max(2 * (x + 100.0), 0.0), 100.0);
-    unit_of_measurement: "%"
-    entity_category: "diagnostic"
+    unit_of_measurement: %
+    entity_category: diagnostic
     device_class: ""
 
   - platform: uptime
     type: seconds
     id: bed_presence_uptime
-    name: "Uptime"
+    name: Uptime
 
 binary_sensor:
   - platform: template
@@ -73,7 +73,7 @@ button:
   - platform: restart
     name: Restart
     id: btn_restart
-    entity_category: "diagnostic"
+    entity_category: diagnostic
 
 switch:
   - platform: template
@@ -81,5 +81,5 @@ switch:
     id: full_range
     optimistic: true
     restore_mode: RESTORE_DEFAULT_OFF
-    entity_category: "config"
+    entity_category: config
     icon: mdi:arrow-expand

--- a/bed-presence-mk1/base.yaml
+++ b/bed-presence-mk1/base.yaml
@@ -25,7 +25,7 @@ sensor:
     id: wifi_signal_percent
     filters:
       - lambda: return min(max(2 * (x + 100.0), 0.0), 100.0);
-    unit_of_measurement: %
+    unit_of_measurement: '%'
     entity_category: diagnostic
     device_class: ""
 

--- a/bed-presence-mk1/base.yaml
+++ b/bed-presence-mk1/base.yaml
@@ -1,3 +1,38 @@
+# Override these values by including a substitutions section in the yaml config that imports this package
+substitutions:
+  # Calibrate Trigger Percentile
+  # This controls how the trigger threshold is set during calibration. During calibration, the unoccupied and occupied
+  # pressure values are determined. This is the percentage of the difference between those values required to trigger
+  # the "occupied" state.
+  #     - 0.75  Requires 75% of the occupied pressure to trigger (Default)
+  #     - 0.50   Set trigger exactly in the middle of unoccupied and occupied pressures
+  #     - 0.25  More sensitive, likely to be triggered by partner
+  trigger_percentile: '0.75'
+
+  # Fast Sensor Delay
+  # This controls how long the "Fast" sensor must register "unoccupied" before reporting. "occupied" is reported
+  # instantly. Without any delay, the sensor will register frequent false negatives as you shift in bed.
+  #     - 2s    Same response as standard sensor
+  #     - 500ms Good starting point for getting speed without too many false negatives (Default)
+  #     - 0ms   No delay, expect frequent false negatives
+  fast_delayed_off: '500ms'
+
+  # Standard Sensor Delay
+  # This controls how long the standard sensor must register "unoccupied" or "occupied" before reporting. This
+  # ensures stability and prevents shifting in bed from registering "unoccupied".
+  standard_delayed_on_off: '2s'
+
+  # Reporting Delta
+  # The sensor must change by this amount before an update is sent (or the reporting_duration_max has been hit)
+  #     - 10.0  Only report very large changes
+  #     - 1.0   Relatively sensitive with much less reporting (default)
+  #     - 0.1   Very sensitive, will report frequently
+  reporting_delta: '1.0'
+
+  # Reporting Duration (Max)
+  # The max amount of time between sensor reports (even if the value hasn't changed)
+  reporting_duration_max: '60s'
+
 packages:
   left_bed_sensor: !include
     file: sensor.yaml

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -1,4 +1,3 @@
-# Override these values by including a substitutions section in the yaml config that imports this package
 substitutions:
   # Calibrate Trigger Percentile
   # This controls how the trigger threshold is set during calibration. During calibration, the unoccupied and occupied
@@ -75,14 +74,9 @@ sensor:
     name: ${sensor_name} Pressure
     id: bed_sensor_${sensor_id}
     update_interval: 0.5s
-    unit_of_measurement: '%'
+    unit_of_measurement: %
     icon: mdi:gauge
     filters:
-      # - calibrate_linear:                         # scale pulses/minute to 0->100%
-      #     method: least_squares
-      #     datapoints:
-      #       - ${calibrate_linear_100} -> 100.0    # 6800Hz (sensor shorted/0ohms)
-      #       - ${calibrate_linear_0} -> 0.0        # 4600Hz (breakforce/10k)
       - lambda: |-                                # scale pulses/minute to 0%->100%
           float cal_0 = id(full_range).state ? 0 : ${calibrate_0};
 
@@ -121,7 +115,7 @@ number:
     name: ${sensor_name} Unoccupied Pressure
     id: val_unoccupied_${sensor_id}
     icon: mdi:gauge-empty
-    unit_of_measurement: '%'
+    unit_of_measurement: %
     entity_category: diagnostic
     optimistic: true
     restore_value: true
@@ -138,7 +132,7 @@ number:
     name: ${sensor_name} Occupied Pressure
     id: val_occupied_${sensor_id}
     icon: mdi:gauge-full
-    unit_of_measurement: '%'
+    unit_of_measurement: %
     entity_category: diagnostic
     optimistic: true
     restore_value: true
@@ -162,7 +156,7 @@ number:
     step: 1.0
     mode: box
     icon: mdi:gauge
-    unit_of_measurement: '%'
+    unit_of_measurement: %
     entity_category: config
 
 button:

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -1,3 +1,30 @@
+# Override these values by including a substitutions section in the yaml config that imports this package
+substitutions:
+  # Calibrate Trigger Percentile
+  # This controls how the trigger threshold is set during calibration. During calibration, the unoccupied and occupied
+  # pressure values are determined. This is the percentage of the difference between those values required to trigger
+  # the "occupied" state.
+  #     - 0.75  Requires 75% of the occupied pressure to trigger (Default)
+  #     - 0.50   Set trigger exactly in the middle of unoccupied and occupied pressures
+  #     - 0.25  More sensitive, likely to be triggered by partner
+  trigger_percentile: '0.75'
+
+  # Fast Sensor Delay
+  # This controls how long the "Fast" sensor must register its value before updating. Without any delay, the sensor
+  # will register frequent fall negatives as you shift in bed.
+  #     - 2s    Same response as standard sensor
+  #     - 500ms Good starting point for getting speed without too many false negatives (Default)
+  #     - 0ms   No delay, expect frequent false negatives
+  fast_delayed_off: '500ms'
+
+  # Reporting Delta
+  # The pressure % must change by this amount before it is reported (note the sensor updates every 60s regardless
+  # of this delta)
+  #     - 10.0  Only report very large changes
+  #     - 1.0   Relatively sensitive with much less reporting (default)
+  #     - 0.1   Very sensitive, will report frequently
+  reporting_delta: 1.0
+
 binary_sensor:
 - platform: template
   name: Bed Occupied ${sensor_name} (Fast)
@@ -36,7 +63,7 @@ sensor:
       max_value: 100.0
       min_value: 0.0
   - or:
-    - delta: 0.1                  # only send if sensor changes by +/-0.1% (eliminate sensor noise)
+    - delta: ${reporting_delta}   # only send if sensor changes by `reporting_delta` (eliminate sensor noise)
     - throttle: 60s               # but still update every minute
 
 number:

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -31,7 +31,7 @@ substitutions:
 
   # Reporting Duration (Max)
   # The max amount of time between sensor reports (even if the value hasn't changed)
-  reporting_duration_max: '60s'
+  reporting_duration_max: '180s'
 
 binary_sensor:
 - platform: template
@@ -65,6 +65,7 @@ sensor:
   pin: ${sensor_gpio}
   name: ${sensor_name} Pressure Raw
   id: bed_sensor_${sensor_id}_raw
+  disabled_by_default: true
   update_interval: 0.5s
   unit_of_measurement: '%'
   icon: mdi:gauge
@@ -80,12 +81,6 @@ sensor:
   # - or:
   #   - delta: ${reporting_delta}           # only send if sensor changes by `reporting_delta` (eliminate sensor noise)
   #   - throttle: ${reporting_duration_max} # but still update every `reporting_duration_max`
-# - platform: copy
-#   source_id: bed_sensor_${sensor_id}
-#   name: ${sensor_name} Pressure Calibrated
-#   id: bed_sensor_${sensor_id}_calibrated
-#   filters:
-#     - lambda: return float(id(val_unoccupied_${sensor_id})).state+((x/100)*(id(val_occupied_${sensor_id}).state - float(id(val_unoccupied_${sensor_id}).state)));
 - platform: copy
   source_id: bed_sensor_${sensor_id}_raw
   name: ${sensor_name} Pressure
@@ -107,6 +102,23 @@ sensor:
     - or:
       - delta: ${reporting_delta}           # only send if sensor changes by `reporting_delta` (eliminate sensor noise)
       - throttle: ${reporting_duration_max} # but still update every `reporting_duration_max`
+- platform: copy
+  source_id: bed_sensor_${sensor_id}_averaged
+  name: ${sensor_name} Pressure Calibrated
+  id: bed_sensor_${sensor_id}_calibrated
+  filters:
+    - lambda: |-
+        float val_cal_top = (x - id(val_unoccupied_${sensor_id}).state) * 100;
+        float val_cal_bot = id(val_occupied_${sensor_id}).state - id(val_unoccupied_${sensor_id}).state;
+        float val_calibrated = val_cal_top/val_cal_bot;
+
+        if (val_calibrated > 100.0 {
+          val_calibrated = 100.0;
+        } else if (val_calibrated < 0.0) {
+          val_calibrated = 0.0;
+        }
+
+        return val_calibrated;
 
 number:
 - platform: template

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -18,8 +18,8 @@ substitutions:
   fast_delayed_off: '500ms'
 
   # Standard Sensor Delay
-  # This controls how long the standard sensor must register "unoccupied" or "occupied" before reporting. This
-  # ensures stability and prevents shifting in bed from registering "unoccupied".
+  # This controls how long the standard sensor must register "unoccupied" or "occupied" before reporting. This ensures
+  # stability and prevents shifting in bed from registering "unoccupied".
   standard_delayed_on_off: '2s'
 
   # Reporting Delta
@@ -34,16 +34,16 @@ substitutions:
   reporting_duration_max: '180s'
 
   # Window Averaging Samples
-  # Add a sliding window moving average to the incoming sensor samples. This specifies the number of samples to
-  # average over. Each sample is 1/2 second.
+  # Add a sliding window moving average to the incoming sensor samples. This specifies the number of samples to average
+  # over. Each sample is 1/2 second.
   #     - 1   Don't perform averaging (DEFAULT)
   #     - 2   Average over 2 samples (1 second)
   #     - 10  Average over 10 samples (5 seconds)
   averaging_window_samples: '1'
 
   # Linear Calibration Points
-  # Change the linear calibration points for the FSR sensor. These values correspond with the raw pulses per
-  # minute from the pulse_counter. Only mess with this if you know what you're doing.
+  # Change the linear calibration points for the FSR sensor. These values correspond with the raw pulses per minute from
+  # the pulse_counter. Only mess with this if you know what you're doing.
   calibrate_linear_100: '408000'
   calibrate_linear_0: '276000'
 

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -153,7 +153,7 @@ button:
       then:
         - number.set:
             id: val_unoccupied_${sensor_id}
-                                # round to 2 decimal places
+            # round to 2 decimal places
             value: !lambda return round(id(bed_sensor_${sensor_id}).state * 100)/100.0;
   - platform: template
     name: Calibrate ${sensor_name} Occupied
@@ -164,12 +164,12 @@ button:
       then:
         - number.set:
             id: val_occupied_${sensor_id}
-                                # round to 2 decimal places
+            # round to 2 decimal places
             value: !lambda return round(id(bed_sensor_${sensor_id}).state * 100)/100.0;
 
 switch:
   - platform: template
-    name: "Clamp Negative Range"
+    name: "Expand Negative Range"
     id: expand_negative_range
     optimistic: true
     restore_mode: RESTORE_DEFAULT_OFF

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -83,9 +83,9 @@ sensor:
       datapoints:
         - ${calibrate_linear_100} -> 100.0         # 6800Hz (sensor shorted/0ohms)
         - ${calibrate_linear_0} -> 0.0           # 4600Hz (breakforce/10k)
-    - sliding_window_moving_average:
-        window_size: ${averaging_window_samples}
-        send_every: 1
+  - sliding_window_moving_average:
+      window_size: ${averaging_window_samples}
+      send_every: 1
   - clamp:
       min_value: 0.0
   - or:

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -82,23 +82,31 @@ sensor:
   #   - throttle: ${reporting_duration_max} # but still update every `reporting_duration_max`
 - platform: copy
   source_id: bed_sensor_${sensor_id}
+  name: ${sensor_name} Pressure Calibrated
+  id: bed_sensor_${sensor_id}_calibrated
+  filters:
+    - lambda: return id(val_unoccupied_${sensor_id})-((x/100)*(id(val_occupied_${sensor_id} - id(val_unoccupied_${sensor_id}))));
+- platform: copy
+  source_id: bed_sensor_${sensor_id}
   name: ${sensor_name} Pressure
   id: bed_sensor_${sensor_id}
   filters:
-  - or:
-    - delta: ${reporting_delta}           # only send if sensor changes by `reporting_delta` (eliminate sensor noise)
-    - throttle: ${reporting_duration_max} # but still update every `reporting_duration_max`
+    - lambda: return x;
+    - or:
+      - delta: ${reporting_delta}           # only send if sensor changes by `reporting_delta` (eliminate sensor noise)
+      - throttle: ${reporting_duration_max} # but still update every `reporting_duration_max`
 - platform: copy
   source_id: bed_sensor_${sensor_id}
   name: ${sensor_name} Pressure Averaged
   id: bed_sensor_${sensor_id}_averaged
   filters:
-  - sliding_window_moving_average:
-      window_size: 10
-      send_every: 1
-  - or:
-    - delta: ${reporting_delta}           # only send if sensor changes by `reporting_delta` (eliminate sensor noise)
-    - throttle: ${reporting_duration_max} # but still update every `reporting_duration_max`
+    - lambda: return x;
+    - sliding_window_moving_average:
+        window_size: 10
+        send_every: 1
+    - or:
+      - delta: ${reporting_delta}           # only send if sensor changes by `reporting_delta` (eliminate sensor noise)
+      - throttle: ${reporting_duration_max} # but still update every `reporting_duration_max`
 
 number:
 - platform: template

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -10,12 +10,17 @@ substitutions:
   trigger_percentile: '0.75'
 
   # Fast Sensor Delay
-  # This controls how long the "Fast" sensor must register its value before updating. Without any delay, the sensor
-  # will register frequent fall negatives as you shift in bed.
+  # This controls how long the "Fast" sensor must register "unoccupied" before reporting. "occupied" is reported
+  # instantly. Without any delay, the sensor will register frequent false negatives as you shift in bed.
   #     - 2s    Same response as standard sensor
   #     - 500ms Good starting point for getting speed without too many false negatives (Default)
   #     - 0ms   No delay, expect frequent false negatives
   fast_delayed_off: '500ms'
+
+  # Standard Sensor Delay
+  # This controls how long the standard sensor must register "unoccupied" or "occupied" before reporting. This
+  # ensures stability and prevents shifting in bed from registering "unoccupied".
+  standard_delayed_on_off: '2s'
 
   # Reporting Delta
   # The sensor must change by this amount before an update is sent (or the reporting_duration_max has been hit)
@@ -27,6 +32,7 @@ substitutions:
   # Reporting Duration (Max)
   # The max amount of time between sensor reports (even if the value hasn't changed)
   reporting_duration_max: '60s'
+
 
 binary_sensor:
 - platform: template
@@ -45,7 +51,7 @@ binary_sensor:
   device_class: occupancy
   icon: mdi:bed
   filters:
-  - delayed_on_off: 2s                # ensure stability
+  - delayed_on_off: ${standard_delayed_on_off}
   lambda: return id(bed_sensor_${sensor_id}).state > id(val_trigger_${sensor_id}).state;
 
 sensor:

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -73,7 +73,7 @@ sensor:
     name: ${sensor_name} Pressure Raw
     id: bed_sensor_${sensor_id}
     update_interval: 0.5s
-    unit_of_measurement: '% raw'
+    unit_of_measurement: '% Raw'
     entity_category: diagnostic
     icon: mdi:gauge
     filters:
@@ -94,6 +94,7 @@ sensor:
     source_id: bed_sensor_${sensor_id}
     name: ${sensor_name} Pressure Calibrated
     id: bed_sensor_${sensor_id}_calibrated
+    unit_of_measurement: '%'
     entity_category: ''
     filters:
       - lambda: |-
@@ -114,7 +115,7 @@ number:
     name: ${sensor_name} Unoccupied Pressure
     id: val_unoccupied_${sensor_id}
     icon: mdi:gauge-empty
-    unit_of_measurement: '% raw'
+    unit_of_measurement: '% Raw'
     entity_category: diagnostic
     optimistic: true
     restore_value: true
@@ -131,7 +132,7 @@ number:
     name: ${sensor_name} Occupied Pressure
     id: val_occupied_${sensor_id}
     icon: mdi:gauge-full
-    unit_of_measurement: '% raw'
+    unit_of_measurement: '% Raw'
     entity_category: diagnostic
     optimistic: true
     restore_value: true
@@ -154,7 +155,7 @@ number:
     max_value: 110
     step: 0.1
     icon: mdi:gauge
-    unit_of_measurement: '% raw'
+    unit_of_measurement: '% Raw'
     entity_category: config
 
 button:

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -4,7 +4,7 @@ substitutions:
   # This controls how the trigger threshold is set during calibration. During calibration, the unoccupied and occupied
   # pressure values are determined. This is the percentage of the difference between those values required to trigger
   # the "occupied" state.
-  #     - 0.75  Requires 75% of the occupied pressure to trigger (Default)
+  #     - 0.75  Requires 75% of the occupied pressure to trigger (DEFAULT)
   #     - 0.50   Set trigger exactly in the middle of unoccupied and occupied pressures
   #     - 0.25  More sensitive, likely to be triggered by partner
   trigger_percentile: '0.75'
@@ -13,7 +13,7 @@ substitutions:
   # This controls how long the "Fast" sensor must register "unoccupied" before reporting. "occupied" is reported
   # instantly. Without any delay, the sensor will register frequent false negatives as you shift in bed.
   #     - 2s    Same response as standard sensor
-  #     - 500ms Good starting point for getting speed without too many false negatives (Default)
+  #     - 500ms Good starting point for getting speed without too many false negatives (DEFAULT)
   #     - 0ms   No delay, expect frequent false negatives
   fast_delayed_off: '500ms'
 
@@ -25,7 +25,7 @@ substitutions:
   # Reporting Delta
   # The sensor must change by this amount before an update is sent (or the reporting_duration_max has been hit)
   #     - 10.0  Only report very large changes
-  #     - 1.0   Relatively sensitive with much less reporting (default)
+  #     - 1.0   Relatively sensitive with much less reporting (DEFAULT)
   #     - 0.1   Very sensitive, will report frequently
   reporting_delta: '1.0'
 
@@ -36,7 +36,7 @@ substitutions:
   # Window Averaging Samples
   # Add a sliding window moving average to the incoming sensor samples. This specifies the number of samples to
   # average over. Each sample is 1/2 second.
-  #     - 1   Don't perform averaging (default)
+  #     - 1   Don't perform averaging (DEFAULT)
   #     - 2   Average over 2 samples (1 second)
   #     - 10  Average over 10 samples (5 seconds)
   averaging_window_samples: '1'

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -112,7 +112,7 @@ sensor:
         float val_cal_bot = id(val_occupied_${sensor_id}).state - id(val_unoccupied_${sensor_id}).state;
         float val_calibrated = val_cal_top/val_cal_bot;
 
-        if (val_calibrated > 100.0 {
+        if (val_calibrated > 100.0) {
           val_calibrated = 100.0;
         } else if (val_calibrated < 0.0) {
           val_calibrated = 0.0;

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -23,15 +23,15 @@ substitutions:
   standard_delayed_on_off: '2s'
 
   # Reporting Delta
-  # The sensor must change by this amount before an update is sent (or the reporting_duration_max has been hit)
+  # The sensor must change by this amount before an update is sent (or the reporting_interval_max has been hit)
   #     - 10.0  Only report very large changes
   #     - 1.0   Relatively sensitive with much less reporting (DEFAULT)
   #     - 0.1   Very sensitive, will report frequently
   reporting_delta: '1.0'
 
-  # Reporting Duration (Max)
+  # Reporting Interval (Max)
   # The max amount of time between sensor reports (even if the value hasn't changed)
-  reporting_duration_max: '180s'
+  reporting_interval_max: '180s'
 
   # Window Averaging Samples
   # Add a sliding window moving average to the incoming sensor samples. This specifies the number of samples to average
@@ -97,7 +97,7 @@ sensor:
           send_every: 1
       - or:
           - delta: ${reporting_delta}             # only send if sensor changes by `reporting_delta` (eliminate sensor noise)
-          - throttle: ${reporting_duration_max}   # but still update every `reporting_duration_max`
+          - throttle: ${reporting_interval_max}   # but still update every `reporting_interval_max`
 
 number:
   - platform: template

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -85,7 +85,7 @@ sensor:
           window_size: ${averaging_window_samples}
           send_every: 1
       - lambda: |-                                # clamp to a min_value of 0 unless expand_range is True
-            if (x >= 0 || id(expand_${sensor_id}_range).state) {
+            if (x >= 0 || id(expand_range).state) {
                 return x;
             } else {
                 return 0;
@@ -166,13 +166,6 @@ button:
             id: val_occupied_${sensor_id}
             # round to 2 decimal places
             value: !lambda return round(id(bed_sensor_${sensor_id}).state * 100)/100.0;
-
-switch:
-  - platform: template
-    name: Expand ${sensor_name} Range
-    id: expand_${sensor_id}_range
-    optimistic: true
-    restore_mode: RESTORE_DEFAULT_OFF
 
 script:
   - id: update_trigger_${sensor_id}

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -1,39 +1,3 @@
-# Override these values by including a substitutions section in the yaml config that imports this package
-substitutions:
-  # Calibrate Trigger Percentile
-  # This controls how the trigger threshold is set during calibration. During calibration, the unoccupied and occupied
-  # pressure values are determined. This is the percentage of the difference between those values required to trigger
-  # the "occupied" state.
-  #     - 0.75  Requires 75% of the occupied pressure to trigger (Default)
-  #     - 0.50   Set trigger exactly in the middle of unoccupied and occupied pressures
-  #     - 0.25  More sensitive, likely to be triggered by partner
-  trigger_percentile: '0.75'
-
-  # Fast Sensor Delay
-  # This controls how long the "Fast" sensor must register "unoccupied" before reporting. "occupied" is reported
-  # instantly. Without any delay, the sensor will register frequent false negatives as you shift in bed.
-  #     - 2s    Same response as standard sensor
-  #     - 500ms Good starting point for getting speed without too many false negatives (Default)
-  #     - 0ms   No delay, expect frequent false negatives
-  fast_delayed_off: '500ms'
-
-  # Standard Sensor Delay
-  # This controls how long the standard sensor must register "unoccupied" or "occupied" before reporting. This
-  # ensures stability and prevents shifting in bed from registering "unoccupied".
-  standard_delayed_on_off: '2s'
-
-  # Reporting Delta
-  # The sensor must change by this amount before an update is sent (or the reporting_duration_max has been hit)
-  #     - 10.0  Only report very large changes
-  #     - 1.0   Relatively sensitive with much less reporting (default)
-  #     - 0.1   Very sensitive, will report frequently
-  reporting_delta: '1.0'
-
-  # Reporting Duration (Max)
-  # The max amount of time between sensor reports (even if the value hasn't changed)
-  reporting_duration_max: '60s'
-
-
 binary_sensor:
 - platform: template
   name: Bed Occupied ${sensor_name} (Fast)
@@ -51,7 +15,7 @@ binary_sensor:
   device_class: occupancy
   icon: mdi:bed
   filters:
-  - delayed_on_off: ${standard_delayed_on_off}
+  - delayed_on_off: ${standard_delayed_on_off}  # ensure stability
   lambda: return id(bed_sensor_${sensor_id}).state > id(val_trigger_${sensor_id}).state;
 
 sensor:

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -75,9 +75,9 @@ sensor:
       datapoints:
         - 408000 -> 100.0         # 6800Hz (sensor shorted/0ohms)
         - 276000 -> 0.0           # 4600Hz (breakforce/10k)
-  # - clamp:
+  - clamp:
   #     max_value: 100.0
-  #     min_value: 0.0
+      min_value: 0.0
   # - or:
   #   - delta: ${reporting_delta}           # only send if sensor changes by `reporting_delta` (eliminate sensor noise)
   #   - throttle: ${reporting_duration_max} # but still update every `reporting_duration_max`

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -98,6 +98,20 @@ sensor:
       - or:
           - delta: ${reporting_delta}             # only send if sensor changes by `reporting_delta` (eliminate sensor noise)
           - throttle: ${reporting_interval_max}   # but still update every `reporting_interval_max`
+  - platform: copy
+    source_id: bed_sensor_${sensor_id}
+    name: ${sensor_name} Pressure Calibrated
+    id: bed_sensor_${sensor_id}_calibrated
+    icon: mdi:scale-balance
+    filters:
+      - lambda: |-                                # scale between val_unoccupied and val_occupied
+          float cal_0 = id(val_unoccupied_${sensor_id}).state;
+          float cal_100 = id(val_occupied_${sensor_id}).state;
+
+          float val = (x - cal_0) * 100;
+          float range = cal100 - cal_0;
+
+          return val/range;
 
 number:
   - platform: template

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -87,7 +87,7 @@ sensor:
 #   filters:
 #     - lambda: return float(id(val_unoccupied_${sensor_id})).state+((x/100)*(id(val_occupied_${sensor_id}).state - float(id(val_unoccupied_${sensor_id}).state)));
 - platform: copy
-  source_id: bed_sensor_${sensor_id}
+  source_id: bed_sensor_${sensor_id}_raw
   name: ${sensor_name} Pressure
   id: bed_sensor_${sensor_id}
   # filters:
@@ -96,7 +96,7 @@ sensor:
   #     - delta: ${reporting_delta}           # only send if sensor changes by `reporting_delta` (eliminate sensor noise)
   #     - throttle: ${reporting_duration_max} # but still update every `reporting_duration_max`
 - platform: copy
-  source_id: bed_sensor_${sensor_id}
+  source_id: bed_sensor_${sensor_id}_raw
   name: ${sensor_name} Pressure Averaged
   id: bed_sensor_${sensor_id}_averaged
   # filters:

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -76,16 +76,20 @@ sensor:
     unit_of_measurement: '%'
     icon: mdi:gauge
     filters:
-      - calibrate_linear:             # scale pulses/minute to 0->100%
+      - calibrate_linear:                         # scale pulses/minute to 0->100%
           method: least_squares
           datapoints:
-            - ${calibrate_linear_100} -> 100.0         # 6800Hz (sensor shorted/0ohms)
-            - ${calibrate_linear_0} -> 0.0           # 4600Hz (breakforce/10k)
+            - ${calibrate_linear_100} -> 100.0    # 6800Hz (sensor shorted/0ohms)
+            - ${calibrate_linear_0} -> 0.0        # 4600Hz (breakforce/10k)
       - sliding_window_moving_average:
           window_size: ${averaging_window_samples}
           send_every: 1
-      - clamp:
-          min_value: 0.0
+      - lambda: |-                                # clamp to a min_value of 0 unless expand_negative_range is True
+            if (x >= 0 || id(expand_negative_range).state) {
+                return x;
+            } else {
+                return 0;
+            }
       - or:
           - delta: ${reporting_delta}             # only send if sensor changes by `reporting_delta` (eliminate sensor noise)
           - throttle: ${reporting_duration_max}   # but still update every `reporting_duration_max`
@@ -100,14 +104,13 @@ number:
     optimistic: true
     restore_value: true
     initial_value: 0
-    min_value: 0      # set to -200ish (calculate) and clamp below based on `extend_negative_range`
+    min_value: -210   # -210 == 0 pulses/minute (expand_negative_range)
     max_value: 110
     step: 1.0
     mode: box
     on_value:
       then:
         - lambda: |-  # Update status and trigger
-            // id(val_unoccupied_status_${sensor_id}).publish_state(x);
             id(update_trigger_${sensor_id})->execute();
   - platform: template
     name: ${sensor_name} Occupied Pressure
@@ -118,14 +121,13 @@ number:
     optimistic: true
     restore_value: true
     initial_value: 100
-    min_value: 0
+    min_value: -210   # -210 == 0 pulses/minute (expand_negative_range)
     max_value: 110
     step: 1.0
     mode: box
     on_value:
       then:
         - lambda: |-  # Update status and trigger
-            // id(val_occupied_status_${sensor_id}).publish_state(x);
             id(update_trigger_${sensor_id})->execute();
   - platform: template
     name: ${sensor_name} Trigger Pressure
@@ -133,7 +135,7 @@ number:
     optimistic: true
     restore_value: true
     initial_value: 50
-    min_value: 0
+    min_value: -210   # -210 == 0 pulses/minute (expand_negative_range)
     max_value: 110
     step: 1.0
     mode: box
@@ -164,6 +166,13 @@ button:
             id: val_occupied_${sensor_id}
                                 # round to 2 decimal places
             value: !lambda return round(id(bed_sensor_${sensor_id}).state * 100)/100.0;
+
+switch:
+  - platform: template
+    name: "Clamp Negative Range"
+    id: expand_negative_range
+    optimistic: true
+    restore_mode: RESTORE_DEFAULT_OFF
 
 script:
   - id: update_trigger_${sensor_id}

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -72,7 +72,6 @@ sensor:
   pin: ${sensor_gpio}
   name: ${sensor_name} Pressure
   id: bed_sensor_${sensor_id}
-  disabled_by_default: true
   update_interval: 0.5s
   unit_of_measurement: '%'
   entity_category: diagnostic
@@ -95,6 +94,7 @@ sensor:
   source_id: bed_sensor_${sensor_id}
   name: ${sensor_name} Pressure Calibrated
   id: bed_sensor_${sensor_id}_calibrated
+  entity_category: ''
   filters:
     - lambda: |-
         float val_cal_top = (x - id(val_unoccupied_${sensor_id}).state) * 100;

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -92,7 +92,7 @@ sensor:
           // 276000ppm = 4600Hz (breakforce/10kohms)
           // 0ppm      = 0Hz    (use full range)
           float calibrate_100 = 408000;
-          float calibrate_0 = id(full_range).state ? 0 : 276000
+          float calibrate_0 = id(full_range).state ? 0 : 276000;
 
           float val_cal_top = (x - calibrate_0) * 100;
           float val_cal_bot = calibrate_100 - calibrate_0;

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -74,7 +74,7 @@ sensor:
     name: ${sensor_name} Pressure
     id: bed_sensor_${sensor_id}
     update_interval: 0.5s
-    unit_of_measurement: %
+    unit_of_measurement: '%'
     icon: mdi:gauge
     filters:
       - lambda: |-                                # scale pulses/minute to 0%->100%
@@ -115,7 +115,7 @@ number:
     name: ${sensor_name} Unoccupied Pressure
     id: val_unoccupied_${sensor_id}
     icon: mdi:gauge-empty
-    unit_of_measurement: %
+    unit_of_measurement: '%'
     entity_category: diagnostic
     optimistic: true
     restore_value: true
@@ -132,7 +132,7 @@ number:
     name: ${sensor_name} Occupied Pressure
     id: val_occupied_${sensor_id}
     icon: mdi:gauge-full
-    unit_of_measurement: %
+    unit_of_measurement: '%'
     entity_category: diagnostic
     optimistic: true
     restore_value: true
@@ -156,7 +156,7 @@ number:
     step: 1.0
     mode: box
     icon: mdi:gauge
-    unit_of_measurement: %
+    unit_of_measurement: '%'
     entity_category: config
 
 button:

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -123,6 +123,7 @@ number:
     min_value: 0
     max_value: 110
     step: 1.0
+    mode: box
     on_value:
       then:
         - lambda: |-  # Update status and trigger
@@ -140,6 +141,7 @@ number:
     min_value: 0
     max_value: 110
     step: 1.0
+    mode: box
     on_value:
       then:
         - lambda: |-  # Update status and trigger
@@ -154,6 +156,7 @@ number:
     min_value: 0
     max_value: 110
     step: 1.0
+    mode: box
     icon: mdi:gauge
     unit_of_measurement: '% Raw'
     entity_category: config

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -84,8 +84,8 @@ sensor:
       - sliding_window_moving_average:
           window_size: ${averaging_window_samples}
           send_every: 1
-      - lambda: |-                                # clamp to a min_value of 0 unless expand_negative_range is True
-            if (x >= 0 || id(expand_negative_range).state) {
+      - lambda: |-                                # clamp to a min_value of 0 unless expand_range is True
+            if (x >= 0 || id(expand_${sensor_id}_range).state) {
                 return x;
             } else {
                 return 0;
@@ -104,7 +104,7 @@ number:
     optimistic: true
     restore_value: true
     initial_value: 0
-    min_value: -210   # -210 == 0 pulses/minute (expand_negative_range)
+    min_value: -210   # -210 == 0 pulses/minute (expand_range)
     max_value: 110
     step: 1.0
     mode: box
@@ -121,7 +121,7 @@ number:
     optimistic: true
     restore_value: true
     initial_value: 100
-    min_value: -210   # -210 == 0 pulses/minute (expand_negative_range)
+    min_value: -210   # -210 == 0 pulses/minute (expand_range)
     max_value: 110
     step: 1.0
     mode: box
@@ -135,7 +135,7 @@ number:
     optimistic: true
     restore_value: true
     initial_value: 50
-    min_value: -210   # -210 == 0 pulses/minute (expand_negative_range)
+    min_value: -210   # -210 == 0 pulses/minute (expand_range)
     max_value: 110
     step: 1.0
     mode: box
@@ -169,8 +169,8 @@ button:
 
 switch:
   - platform: template
-    name: "Expand Negative Range"
-    id: expand_negative_range
+    name: Expand ${sensor_name} Range
+    id: expand_${sensor_id}_range
     optimistic: true
     restore_mode: RESTORE_DEFAULT_OFF
 

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -94,7 +94,7 @@ sensor:
           - throttle: ${reporting_interval_max}   # but still update every `reporting_interval_max`
   - platform: copy
     source_id: bed_sensor_${sensor_id}
-    name: ${sensor_name} Pressure Calibrated
+    name: Calibrated ${sensor_name} Pressure
     id: bed_sensor_${sensor_id}_calibrated
     icon: mdi:scale-balance
     filters:

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -90,23 +90,23 @@ sensor:
   source_id: bed_sensor_${sensor_id}
   name: ${sensor_name} Pressure
   id: bed_sensor_${sensor_id}
-  filters:
-    - lambda: return x;
-    - or:
-      - delta: ${reporting_delta}           # only send if sensor changes by `reporting_delta` (eliminate sensor noise)
-      - throttle: ${reporting_duration_max} # but still update every `reporting_duration_max`
+  # filters:
+  #   - lambda: return x;
+  #   - or:
+  #     - delta: ${reporting_delta}           # only send if sensor changes by `reporting_delta` (eliminate sensor noise)
+  #     - throttle: ${reporting_duration_max} # but still update every `reporting_duration_max`
 - platform: copy
   source_id: bed_sensor_${sensor_id}
   name: ${sensor_name} Pressure Averaged
   id: bed_sensor_${sensor_id}_averaged
-  filters:
-    - lambda: return x;
-    - sliding_window_moving_average:
-        window_size: 10
-        send_every: 1
-    - or:
-      - delta: ${reporting_delta}           # only send if sensor changes by `reporting_delta` (eliminate sensor noise)
-      - throttle: ${reporting_duration_max} # but still update every `reporting_duration_max`
+  # filters:
+  #   - lambda: return x;
+  #   - sliding_window_moving_average:
+  #       window_size: 10
+  #       send_every: 1
+  #   - or:
+  #     - delta: ${reporting_delta}           # only send if sensor changes by `reporting_delta` (eliminate sensor noise)
+  #     - throttle: ${reporting_duration_max} # but still update every `reporting_duration_max`
 
 number:
 - platform: template

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -23,7 +23,7 @@ substitutions:
   #     - 10.0  Only report very large changes
   #     - 1.0   Relatively sensitive with much less reporting (default)
   #     - 0.1   Very sensitive, will report frequently
-  reporting_delta: 1.0
+  reporting_delta: '1.0'
 
 binary_sensor:
 - platform: template

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -53,11 +53,18 @@ binary_sensor:
   - delayed_on_off: ${standard_delayed_on_off}  # ensure stability
   lambda: return id(bed_sensor_${sensor_id}).state > id(val_trigger_${sensor_id}).state;
 
+- platform: template
+  name: Bed Occupied ${sensor_name} (Averaged)
+  id: bed_occupied_${sensor_id}_averaged
+  device_class: occupancy
+  icon: mdi:bed
+  lambda: return id(bed_sensor_${sensor_id}_averaged).state > id(val_trigger_${sensor_id}).state;
+
 sensor:
 - platform: pulse_counter
   pin: ${sensor_gpio}
-  name: ${sensor_name} Pressure
-  id: bed_sensor_${sensor_id}
+  name: ${sensor_name} Pressure Raw
+  id: bed_sensor_${sensor_id}_raw
   update_interval: 0.5s
   unit_of_measurement: '%'
   icon: mdi:gauge
@@ -67,9 +74,28 @@ sensor:
       datapoints:
         - 408000 -> 100.0         # 6800Hz (sensor shorted/0ohms)
         - 276000 -> 0.0           # 4600Hz (breakforce/10k)
-  - clamp:
-      max_value: 100.0
-      min_value: 0.0
+  # - clamp:
+  #     max_value: 100.0
+  #     min_value: 0.0
+  # - or:
+  #   - delta: ${reporting_delta}           # only send if sensor changes by `reporting_delta` (eliminate sensor noise)
+  #   - throttle: ${reporting_duration_max} # but still update every `reporting_duration_max`
+- platform: copy
+  source_id: bed_sensor_${sensor_id}
+  name: ${sensor_name} Pressure
+  id: bed_sensor_${sensor_id}
+  filters:
+  - or:
+    - delta: ${reporting_delta}           # only send if sensor changes by `reporting_delta` (eliminate sensor noise)
+    - throttle: ${reporting_duration_max} # but still update every `reporting_duration_max`
+- platform: copy
+  source_id: bed_sensor_${sensor_id}
+  name: ${sensor_name} Pressure Averaged
+  id: bed_sensor_${sensor_id}_averaged
+  filters:
+  - sliding_window_moving_average:
+      window_size: 10
+      send_every: 1
   - or:
     - delta: ${reporting_delta}           # only send if sensor changes by `reporting_delta` (eliminate sensor noise)
     - throttle: ${reporting_duration_max} # but still update every `reporting_duration_max`

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -90,23 +90,23 @@ sensor:
   source_id: bed_sensor_${sensor_id}_raw
   name: ${sensor_name} Pressure
   id: bed_sensor_${sensor_id}
-  # filters:
-  #   - lambda: return x;
-  #   - or:
-  #     - delta: ${reporting_delta}           # only send if sensor changes by `reporting_delta` (eliminate sensor noise)
-  #     - throttle: ${reporting_duration_max} # but still update every `reporting_duration_max`
+  filters:
+    # - lambda: return x;
+    - or:
+      - delta: ${reporting_delta}           # only send if sensor changes by `reporting_delta` (eliminate sensor noise)
+      - throttle: ${reporting_duration_max} # but still update every `reporting_duration_max`
 - platform: copy
   source_id: bed_sensor_${sensor_id}_raw
   name: ${sensor_name} Pressure Averaged
   id: bed_sensor_${sensor_id}_averaged
-  # filters:
-  #   - lambda: return x;
-  #   - sliding_window_moving_average:
-  #       window_size: 10
-  #       send_every: 1
-  #   - or:
-  #     - delta: ${reporting_delta}           # only send if sensor changes by `reporting_delta` (eliminate sensor noise)
-  #     - throttle: ${reporting_duration_max} # but still update every `reporting_duration_max`
+  filters:
+    # - lambda: return x;
+    - sliding_window_moving_average:
+        window_size: 10
+        send_every: 1
+    - or:
+      - delta: ${reporting_delta}           # only send if sensor changes by `reporting_delta` (eliminate sensor noise)
+      - throttle: ${reporting_duration_max} # but still update every `reporting_duration_max`
 
 number:
 - platform: template

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -1,3 +1,38 @@
+# Override these values by including a substitutions section in the yaml config that imports this package
+substitutions:
+  # Calibrate Trigger Percentile
+  # This controls how the trigger threshold is set during calibration. During calibration, the unoccupied and occupied
+  # pressure values are determined. This is the percentage of the difference between those values required to trigger
+  # the "occupied" state.
+  #     - 0.75  Requires 75% of the occupied pressure to trigger (Default)
+  #     - 0.50   Set trigger exactly in the middle of unoccupied and occupied pressures
+  #     - 0.25  More sensitive, likely to be triggered by partner
+  trigger_percentile: '0.75'
+
+  # Fast Sensor Delay
+  # This controls how long the "Fast" sensor must register "unoccupied" before reporting. "occupied" is reported
+  # instantly. Without any delay, the sensor will register frequent false negatives as you shift in bed.
+  #     - 2s    Same response as standard sensor
+  #     - 500ms Good starting point for getting speed without too many false negatives (Default)
+  #     - 0ms   No delay, expect frequent false negatives
+  fast_delayed_off: '500ms'
+
+  # Standard Sensor Delay
+  # This controls how long the standard sensor must register "unoccupied" or "occupied" before reporting. This
+  # ensures stability and prevents shifting in bed from registering "unoccupied".
+  standard_delayed_on_off: '2s'
+
+  # Reporting Delta
+  # The sensor must change by this amount before an update is sent (or the reporting_duration_max has been hit)
+  #     - 10.0  Only report very large changes
+  #     - 1.0   Relatively sensitive with much less reporting (default)
+  #     - 0.1   Very sensitive, will report frequently
+  reporting_delta: '1.0'
+
+  # Reporting Duration (Max)
+  # The max amount of time between sensor reports (even if the value hasn't changed)
+  reporting_duration_max: '60s'
+
 binary_sensor:
 - platform: template
   name: Bed Occupied ${sensor_name} (Fast)

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -41,11 +41,11 @@ substitutions:
   #     - 10  Average over 10 samples (5 seconds)
   averaging_window_samples: '1'
 
-  # Linear Calibration Points
-  # Change the linear calibration points for the FSR sensor. These values correspond with the raw pulses per minute from
-  # the pulse_counter. Only mess with this if you know what you're doing.
-  calibrate_linear_100: '408000'
-  calibrate_linear_0: '276000'
+  # # Linear Calibration Points
+  # # Change the linear calibration points for the FSR sensor. These values correspond with the raw pulses per minute from
+  # # the pulse_counter. Only mess with this if you know what you're doing.
+  # calibrate_linear_100: '408000'
+  # calibrate_linear_0: '276000'
 
 binary_sensor:
   - platform: template
@@ -76,23 +76,30 @@ sensor:
     unit_of_measurement: '%'
     icon: mdi:gauge
     filters:
-      - calibrate_linear:                         # scale pulses/minute to 0->100%
-          method: least_squares
-          datapoints:
-            - ${calibrate_linear_100} -> 100.0    # 6800Hz (sensor shorted/0ohms)
-            - ${calibrate_linear_0} -> 0.0        # 4600Hz (breakforce/10k)
+      # - calibrate_linear:                         # scale pulses/minute to 0->100%
+      #     method: least_squares
+      #     datapoints:
+      #       - ${calibrate_linear_100} -> 100.0    # 6800Hz (sensor shorted/0ohms)
+      #       - ${calibrate_linear_0} -> 0.0        # 4600Hz (breakforce/10k)
       - sliding_window_moving_average:
           window_size: ${averaging_window_samples}
           send_every: 1
-      - lambda: |-                                # clamp to a min_value of 0 unless expand_range is True
-            if (x >= 0 || id(expand_range).state) {
-                return x;
-            } else {
-                return 0;
-            }
       - or:
           - delta: ${reporting_delta}             # only send if sensor changes by `reporting_delta` (eliminate sensor noise)
           - throttle: ${reporting_duration_max}   # but still update every `reporting_duration_max`
+      - lambda: |-                                # scale pulses/minute to 0%->100%
+          // 408000ppm = 6800Hz (sensor shorted/0ohms)
+          // 276000ppm = 4600Hz (breakforce/10kohms)
+          // 0ppm      = 0Hz    (use full range)
+          float calibrate_100 = 408000;
+          float calibrate_0 = id(full_range).state ? 0 : 276000
+
+          float val_cal_top = (x - calibrate_0) * 100;
+          float val_cal_bot = calibrate_100 - calibrate_0;
+
+          return val_cal_top/val_cal_bot;
+      - clamp:
+          min_value: 0
 
 number:
   - platform: template
@@ -104,13 +111,13 @@ number:
     optimistic: true
     restore_value: true
     initial_value: 0
-    min_value: -210   # -210 == 0 pulses/minute (expand_range)
+    min_value: 0
     max_value: 110
     step: 1.0
     mode: box
     on_value:
       then:
-        - lambda: |-  # Update status and trigger
+        - lambda: |-  # Update trigger
             id(update_trigger_${sensor_id})->execute();
   - platform: template
     name: ${sensor_name} Occupied Pressure
@@ -121,13 +128,13 @@ number:
     optimistic: true
     restore_value: true
     initial_value: 100
-    min_value: -210   # -210 == 0 pulses/minute (expand_range)
+    min_value: 0
     max_value: 110
     step: 1.0
     mode: box
     on_value:
       then:
-        - lambda: |-  # Update status and trigger
+        - lambda: |-  # Update trigger
             id(update_trigger_${sensor_id})->execute();
   - platform: template
     name: ${sensor_name} Trigger Pressure
@@ -135,7 +142,7 @@ number:
     optimistic: true
     restore_value: true
     initial_value: 50
-    min_value: -210   # -210 == 0 pulses/minute (expand_range)
+    min_value: 0
     max_value: 110
     step: 1.0
     mode: box

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -80,12 +80,12 @@ sensor:
   # - or:
   #   - delta: ${reporting_delta}           # only send if sensor changes by `reporting_delta` (eliminate sensor noise)
   #   - throttle: ${reporting_duration_max} # but still update every `reporting_duration_max`
-- platform: copy
-  source_id: bed_sensor_${sensor_id}
-  name: ${sensor_name} Pressure Calibrated
-  id: bed_sensor_${sensor_id}_calibrated
-  filters:
-    - lambda: return float(id(val_unoccupied_${sensor_id})).state+((x/100)*(id(val_occupied_${sensor_id}).state - float(id(val_unoccupied_${sensor_id}).state)));
+# - platform: copy
+#   source_id: bed_sensor_${sensor_id}
+#   name: ${sensor_name} Pressure Calibrated
+#   id: bed_sensor_${sensor_id}_calibrated
+#   filters:
+#     - lambda: return float(id(val_unoccupied_${sensor_id})).state+((x/100)*(id(val_occupied_${sensor_id}).state - float(id(val_unoccupied_${sensor_id}).state)));
 - platform: copy
   source_id: bed_sensor_${sensor_id}
   name: ${sensor_name} Pressure

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -48,152 +48,152 @@ substitutions:
   calibrate_linear_0: '276000'
 
 binary_sensor:
-- platform: template
-  name: Bed Occupied ${sensor_name} (Fast)
-  id: bed_occupied_${sensor_id}_fast
-  device_class: occupancy
-  icon: mdi:bed
-  disabled_by_default: true
-  filters:
-  - delayed_off: ${fast_delayed_off}  # prevent shifting in bed from registering "off"
-  lambda: return id(bed_sensor_${sensor_id}).state > id(val_trigger_${sensor_id}).state;
+  - platform: template
+    name: Bed Occupied ${sensor_name} (Fast)
+    id: bed_occupied_${sensor_id}_fast
+    device_class: occupancy
+    icon: mdi:bed
+    disabled_by_default: true
+    filters:
+      - delayed_off: ${fast_delayed_off}  # prevent shifting in bed from registering "off"
+    lambda: return id(bed_sensor_${sensor_id}).state > id(val_trigger_${sensor_id}).state;
 
-- platform: template
-  name: Bed Occupied ${sensor_name}
-  id: bed_occupied_${sensor_id}
-  device_class: occupancy
-  icon: mdi:bed
-  filters:
-  - delayed_on_off: ${standard_delayed_on_off}  # ensure stability
-  lambda: return id(bed_sensor_${sensor_id}).state > id(val_trigger_${sensor_id}).state;
+  - platform: template
+    name: Bed Occupied ${sensor_name}
+    id: bed_occupied_${sensor_id}
+    device_class: occupancy
+    icon: mdi:bed
+    filters:
+      - delayed_on_off: ${standard_delayed_on_off}  # ensure stability
+    lambda: return id(bed_sensor_${sensor_id}).state > id(val_trigger_${sensor_id}).state;
 
 sensor:
-- platform: pulse_counter   # Raw Sensor
-  pin: ${sensor_gpio}
-  name: ${sensor_name} Pressure
-  id: bed_sensor_${sensor_id}
-  update_interval: 0.5s
-  unit_of_measurement: '%'
-  entity_category: diagnostic
-  icon: mdi:gauge
-  filters:
-  - calibrate_linear:             # scale pulses/minute to 0->100%
-      method: least_squares
-      datapoints:
-        - ${calibrate_linear_100} -> 100.0         # 6800Hz (sensor shorted/0ohms)
-        - ${calibrate_linear_0} -> 0.0           # 4600Hz (breakforce/10k)
-  - sliding_window_moving_average:
-      window_size: ${averaging_window_samples}
-      send_every: 1
-  - clamp:
-      min_value: 0.0
-  - or:
-    - delta: ${reporting_delta}           # only send if sensor changes by `reporting_delta` (eliminate sensor noise)
-    - throttle: ${reporting_duration_max} # but still update every `reporting_duration_max`
-- platform: copy  # Calibrated Sensor (Runs between val_unoccupied (0%) and val_occupied (100%))
-  source_id: bed_sensor_${sensor_id}
-  name: ${sensor_name} Pressure Calibrated
-  id: bed_sensor_${sensor_id}_calibrated
-  entity_category: ''
-  filters:
-    - lambda: |-
-        float val_cal_top = (x - id(val_unoccupied_${sensor_id}).state) * 100;
-        float val_cal_bot = id(val_occupied_${sensor_id}).state - id(val_unoccupied_${sensor_id}).state;
-        float val_calibrated = val_cal_top/val_cal_bot;
+  - platform: pulse_counter   # Raw Sensor
+    pin: ${sensor_gpio}
+    name: ${sensor_name} Pressure
+    id: bed_sensor_${sensor_id}
+    update_interval: 0.5s
+    unit_of_measurement: '%'
+    entity_category: diagnostic
+    icon: mdi:gauge
+    filters:
+      - calibrate_linear:             # scale pulses/minute to 0->100%
+          method: least_squares
+          datapoints:
+            - ${calibrate_linear_100} -> 100.0         # 6800Hz (sensor shorted/0ohms)
+            - ${calibrate_linear_0} -> 0.0           # 4600Hz (breakforce/10k)
+      - sliding_window_moving_average:
+          window_size: ${averaging_window_samples}
+          send_every: 1
+      - clamp:
+          min_value: 0.0
+      - or:
+          - delta: ${reporting_delta}             # only send if sensor changes by `reporting_delta` (eliminate sensor noise)
+          - throttle: ${reporting_duration_max}   # but still update every `reporting_duration_max`
+  - platform: copy  # Calibrated Sensor (Runs between val_unoccupied (0%) and val_occupied (100%))
+    source_id: bed_sensor_${sensor_id}
+    name: ${sensor_name} Pressure Calibrated
+    id: bed_sensor_${sensor_id}_calibrated
+    entity_category: ''
+    filters:
+      - lambda: |-
+          float val_cal_top = (x - id(val_unoccupied_${sensor_id}).state) * 100;
+          float val_cal_bot = id(val_occupied_${sensor_id}).state - id(val_unoccupied_${sensor_id}).state;
+          float val_calibrated = val_cal_top/val_cal_bot;
 
-        if (val_calibrated > 100.0) {
-          val_calibrated = 100.0;
-        } else if (val_calibrated < 0.0) {
-          val_calibrated = 0.0;
-        }
+          if (val_calibrated > 100.0) {
+            val_calibrated = 100.0;
+          } else if (val_calibrated < 0.0) {
+            val_calibrated = 0.0;
+          }
 
-        return val_calibrated;
+          return val_calibrated;
 
 number:
-- platform: template
-  name: ${sensor_name} Unoccupied Pressure
-  id: val_unoccupied_${sensor_id}
-  icon: mdi:gauge-empty
-  unit_of_measurement: '%'
-  entity_category: diagnostic
-  optimistic: true
-  restore_value: true
-  initial_value: 0
-  min_value: 0
-  max_value: 110
-  step: 0.1
-  on_value:
-    then:
-    - lambda: |-  # Update status and trigger
-        // id(val_unoccupied_status_${sensor_id}).publish_state(x);
-        id(update_trigger_${sensor_id})->execute();
-- platform: template
-  name: ${sensor_name} Occupied Pressure
-  id: val_occupied_${sensor_id}
-  icon: mdi:gauge-full
-  unit_of_measurement: '%'
-  entity_category: diagnostic
-  optimistic: true
-  restore_value: true
-  initial_value: 100
-  min_value: 0
-  max_value: 110
-  step: 0.1
-  on_value:
-    then:
-    - lambda: |-  # Update status and trigger
-        // id(val_occupied_status_${sensor_id}).publish_state(x);
-        id(update_trigger_${sensor_id})->execute();
-- platform: template
-  name: ${sensor_name} Trigger Pressure
-  id: val_trigger_${sensor_id}
-  optimistic: true
-  restore_value: true
-  initial_value: 50
-  min_value: 0
-  max_value: 110
-  step: 0.1
-  icon: mdi:gauge
-  unit_of_measurement: '%'
-  entity_category: config
+  - platform: template
+    name: ${sensor_name} Unoccupied Pressure
+    id: val_unoccupied_${sensor_id}
+    icon: mdi:gauge-empty
+    unit_of_measurement: '%'
+    entity_category: diagnostic
+    optimistic: true
+    restore_value: true
+    initial_value: 0
+    min_value: 0
+    max_value: 110
+    step: 0.1
+    on_value:
+      then:
+        - lambda: |-  # Update status and trigger
+            // id(val_unoccupied_status_${sensor_id}).publish_state(x);
+            id(update_trigger_${sensor_id})->execute();
+  - platform: template
+    name: ${sensor_name} Occupied Pressure
+    id: val_occupied_${sensor_id}
+    icon: mdi:gauge-full
+    unit_of_measurement: '%'
+    entity_category: diagnostic
+    optimistic: true
+    restore_value: true
+    initial_value: 100
+    min_value: 0
+    max_value: 110
+    step: 0.1
+    on_value:
+      then:
+        - lambda: |-  # Update status and trigger
+            // id(val_occupied_status_${sensor_id}).publish_state(x);
+            id(update_trigger_${sensor_id})->execute();
+  - platform: template
+    name: ${sensor_name} Trigger Pressure
+    id: val_trigger_${sensor_id}
+    optimistic: true
+    restore_value: true
+    initial_value: 50
+    min_value: 0
+    max_value: 110
+    step: 0.1
+    icon: mdi:gauge
+    unit_of_measurement: '%'
+    entity_category: config
 
 button:
-- platform: template
-  name: Calibrate ${sensor_name} Unoccupied
-  id: calibration_${sensor_id}_set_unoccupied
-  icon: mdi:bed-empty
-  entity_category: config
-  on_press:
-    then:
-    - number.set:
-        id: val_unoccupied_${sensor_id}
-        value: !lambda return id(bed_sensor_${sensor_id}).state;
-- platform: template
-  name: Calibrate ${sensor_name} Occupied
-  id: calibration_${sensor_id}_set_occupied
-  icon: mdi:bed
-  entity_category: config
-  on_press:
-    then:
-    - number.set:
-        id: val_occupied_${sensor_id}
-        value: !lambda return id(bed_sensor_${sensor_id}).state;
+  - platform: template
+    name: Calibrate ${sensor_name} Unoccupied
+    id: calibration_${sensor_id}_set_unoccupied
+    icon: mdi:bed-empty
+    entity_category: config
+    on_press:
+      then:
+        - number.set:
+            id: val_unoccupied_${sensor_id}
+            value: !lambda return id(bed_sensor_${sensor_id}).state;
+  - platform: template
+    name: Calibrate ${sensor_name} Occupied
+    id: calibration_${sensor_id}_set_occupied
+    icon: mdi:bed
+    entity_category: config
+    on_press:
+      then:
+        - number.set:
+            id: val_occupied_${sensor_id}
+            value: !lambda return id(bed_sensor_${sensor_id}).state;
 
 script:
-- id: update_trigger_${sensor_id}
-  mode: queued
-  then:
-  - lambda: |-  # Set trigger to x% of difference between min/max
-      float unoccupied_pressure = id(val_unoccupied_${sensor_id}).state;
-      float occupied_pressure = id(val_occupied_${sensor_id}).state;
+  - id: update_trigger_${sensor_id}
+    mode: queued
+    then:
+      - lambda: |-  # Set trigger to x% of difference between min/max
+          float unoccupied_pressure = id(val_unoccupied_${sensor_id}).state;
+          float occupied_pressure = id(val_occupied_${sensor_id}).state;
 
-      // calculate new trigger value
-      float trigger_pressure = unoccupied_pressure + ((occupied_pressure - unoccupied_pressure) * float(${trigger_percentile}));
+          // calculate new trigger value
+          float trigger_pressure = unoccupied_pressure + ((occupied_pressure - unoccupied_pressure) * float(${trigger_percentile}));
 
-      // round to 2 decimal places
-      trigger_pressure = round(trigger_pressure * 100)/100.0;
+          // round to 2 decimal places
+          trigger_pressure = round(trigger_pressure * 100)/100.0;
 
-      // set value
-      auto call = id(val_trigger_${sensor_id}).make_call();
-      call.set_value(trigger_pressure);
-      call.perform();
+          // set value
+          auto call = id(val_trigger_${sensor_id}).make_call();
+          call.set_value(trigger_pressure);
+          call.perform();

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -70,7 +70,7 @@ binary_sensor:
 sensor:
   - platform: pulse_counter   # Raw Sensor
     pin: ${sensor_gpio}
-    name: ${sensor_name} Pressure Raw
+    name: ${sensor_name} Pressure
     id: bed_sensor_${sensor_id}
     update_interval: 0.5s
     unit_of_measurement: '% Raw'

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -70,10 +70,10 @@ binary_sensor:
 sensor:
   - platform: pulse_counter   # Raw Sensor
     pin: ${sensor_gpio}
-    name: ${sensor_name} Pressure
+    name: ${sensor_name} Pressure Raw
     id: bed_sensor_${sensor_id}
     update_interval: 0.5s
-    unit_of_measurement: '%'
+    unit_of_measurement: '% raw'
     entity_category: diagnostic
     icon: mdi:gauge
     filters:
@@ -114,7 +114,7 @@ number:
     name: ${sensor_name} Unoccupied Pressure
     id: val_unoccupied_${sensor_id}
     icon: mdi:gauge-empty
-    unit_of_measurement: '%'
+    unit_of_measurement: '% raw'
     entity_category: diagnostic
     optimistic: true
     restore_value: true
@@ -131,7 +131,7 @@ number:
     name: ${sensor_name} Occupied Pressure
     id: val_occupied_${sensor_id}
     icon: mdi:gauge-full
-    unit_of_measurement: '%'
+    unit_of_measurement: '% raw'
     entity_category: diagnostic
     optimistic: true
     restore_value: true
@@ -154,7 +154,7 @@ number:
     max_value: 110
     step: 0.1
     icon: mdi:gauge
-    unit_of_measurement: '%'
+    unit_of_measurement: '% raw'
     entity_category: config
 
 button:

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -8,18 +8,28 @@ substitutions:
   #     - 0.25  More sensitive, likely to be triggered by partner
   trigger_percentile: '0.75'
 
+  # Window Averaging Samples
+  # Add a sliding window moving average to the incoming sensor samples. This specifies the number of samples to average
+  # over. Each sample is 1/2 second.
+  #     - 1   Don't perform averaging
+  #     - 5   Average over 5 samples (2.5 seconds) (DEFAULT)
+  #     - 10  Average over 10 samples (5 seconds)
+  averaging_window_samples: '5'
+
   # Fast Sensor Delay
-  # This controls how long the "Fast" sensor must register "unoccupied" before reporting. "occupied" is reported
-  # instantly. Without any delay, the sensor will register frequent false negatives as you shift in bed.
+  # This controls how long the "Fast" sensor must register "unoccupied" or "occupied" before reporting. Averaging or
+  # delay is encourage to prevent frequent false negatives as you shift in bed.
   #     - 2s    Same response as standard sensor
-  #     - 500ms Good starting point for getting speed without too many false negatives (DEFAULT)
-  #     - 0ms   No delay, expect frequent false negatives
-  fast_delayed_off: '500ms'
+  #     - 500ms Good starting point for getting speed without too many false negatives
+  #     - 0ms   No delay (DEFAULT)
+  fast_delayed_on: '0ms'
+  fast_delayed_off: '0ms'
 
   # Standard Sensor Delay
-  # This controls how long the standard sensor must register "unoccupied" or "occupied" before reporting. This ensures
-  # stability and prevents shifting in bed from registering "unoccupied".
-  standard_delayed_on_off: '2s'
+  # This controls how long the standard sensor must register "unoccupied" or "occupied" before reporting. Averaging or
+  # delay is enocuraged to ensure stability.
+  standard_delayed_on: '0s'
+  standard_delayed_off: '1s'
 
   # Reporting Delta
   # The sensor must change by this amount before an update is sent (or the reporting_interval_max has been hit)
@@ -31,14 +41,6 @@ substitutions:
   # Reporting Interval (Max)
   # The max amount of time between sensor reports (even if the value hasn't changed)
   reporting_interval_max: '180s'
-
-  # Window Averaging Samples
-  # Add a sliding window moving average to the incoming sensor samples. This specifies the number of samples to average
-  # over. Each sample is 1/2 second.
-  #     - 1   Don't perform averaging (DEFAULT)
-  #     - 2   Average over 2 samples (1 second)
-  #     - 10  Average over 10 samples (5 seconds)
-  averaging_window_samples: '1'
 
   # Linear Calibration Points
   # Change the linear calibration points for the FSR sensor. These values correspond with the raw pulses per minute from
@@ -56,6 +58,7 @@ binary_sensor:
     icon: mdi:bed
     disabled_by_default: true
     filters:
+      - delayed_on: ${fast_delayed_on}
       - delayed_off: ${fast_delayed_off}  # prevent shifting in bed from registering "off"
     lambda: return id(bed_sensor_${sensor_id}).state > id(val_trigger_${sensor_id}).state;
 
@@ -65,7 +68,8 @@ binary_sensor:
     device_class: occupancy
     icon: mdi:bed
     filters:
-      - delayed_on_off: ${standard_delayed_on_off}  # ensure stability
+      - delayed_on: ${standard_delayed_on}
+      - delayed_off: ${standard_delayed_off}
     lambda: return id(bed_sensor_${sensor_id}).state > id(val_trigger_${sensor_id}).state;
 
 sensor:

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -18,12 +18,15 @@ substitutions:
   fast_delayed_off: '500ms'
 
   # Reporting Delta
-  # The pressure % must change by this amount before it is reported (note the sensor updates every 60s regardless
-  # of this delta)
+  # The sensor must change by this amount before an update is sent (or the reporting_duration_max has been hit)
   #     - 10.0  Only report very large changes
   #     - 1.0   Relatively sensitive with much less reporting (default)
   #     - 0.1   Very sensitive, will report frequently
   reporting_delta: '1.0'
+
+  # Reporting Duration (Max)
+  # The max amount of time between sensor reports (even if the value hasn't changed)
+  reporting_duration_max: '60s'
 
 binary_sensor:
 - platform: template
@@ -63,8 +66,8 @@ sensor:
       max_value: 100.0
       min_value: 0.0
   - or:
-    - delta: ${reporting_delta}   # only send if sensor changes by `reporting_delta` (eliminate sensor noise)
-    - throttle: 60s               # but still update every minute
+    - delta: ${reporting_delta}           # only send if sensor changes by `reporting_delta` (eliminate sensor noise)
+    - throttle: ${reporting_duration_max} # but still update every `reporting_duration_max`
 
 number:
 - platform: template

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -41,11 +41,13 @@ substitutions:
   #     - 10  Average over 10 samples (5 seconds)
   averaging_window_samples: '1'
 
-  # # Linear Calibration Points
-  # # Change the linear calibration points for the FSR sensor. These values correspond with the raw pulses per minute from
-  # # the pulse_counter. Only mess with this if you know what you're doing.
-  # calibrate_linear_100: '408000'
-  # calibrate_linear_0: '276000'
+  # Linear Calibration Points
+  # Change the linear calibration points for the FSR sensor. These values correspond with the raw pulses per minute from
+  # the pulse_counter. Only mess with this if you know what you're doing. In standard mode (Full Range = False), the
+  # sensor is linearly calibrated between calibrate_0 (0%) and calibreate_100 (100%). When Full Range = True,
+  # calibrate_0 is set to 0.
+  calibrate_100: '408000'
+  calibrate_0: '276000'
 
 binary_sensor:
   - platform: template
@@ -81,25 +83,21 @@ sensor:
       #     datapoints:
       #       - ${calibrate_linear_100} -> 100.0    # 6800Hz (sensor shorted/0ohms)
       #       - ${calibrate_linear_0} -> 0.0        # 4600Hz (breakforce/10k)
+      - lambda: |-                                # scale pulses/minute to 0%->100%
+          float cal_0 = id(full_range).state ? 0 : ${calibrate_0};
+
+          float val = (x - cal_0) * 100;
+          float range = ${calibrate_100} - cal_0;
+
+          return val/range;
+      - clamp:
+          min_value: 0
       - sliding_window_moving_average:
           window_size: ${averaging_window_samples}
           send_every: 1
       - or:
           - delta: ${reporting_delta}             # only send if sensor changes by `reporting_delta` (eliminate sensor noise)
           - throttle: ${reporting_duration_max}   # but still update every `reporting_duration_max`
-      - lambda: |-                                # scale pulses/minute to 0%->100%
-          // 408000ppm = 6800Hz (sensor shorted/0ohms)
-          // 276000ppm = 4600Hz (breakforce/10kohms)
-          // 0ppm      = 0Hz    (use full range)
-          float calibrate_100 = 408000;
-          float calibrate_0 = id(full_range).state ? 0 : 276000;
-
-          float val_cal_top = (x - calibrate_0) * 100;
-          float val_cal_bot = calibrate_100 - calibrate_0;
-
-          return val_cal_top/val_cal_bot;
-      - clamp:
-          min_value: 0
 
 number:
   - platform: template

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -68,13 +68,12 @@ binary_sensor:
     lambda: return id(bed_sensor_${sensor_id}).state > id(val_trigger_${sensor_id}).state;
 
 sensor:
-  - platform: pulse_counter   # Raw Sensor
+  - platform: pulse_counter
     pin: ${sensor_gpio}
     name: ${sensor_name} Pressure
     id: bed_sensor_${sensor_id}
     update_interval: 0.5s
-    unit_of_measurement: '% Raw'
-    entity_category: diagnostic
+    unit_of_measurement: '%'
     icon: mdi:gauge
     filters:
       - calibrate_linear:             # scale pulses/minute to 0->100%
@@ -90,37 +89,18 @@ sensor:
       - or:
           - delta: ${reporting_delta}             # only send if sensor changes by `reporting_delta` (eliminate sensor noise)
           - throttle: ${reporting_duration_max}   # but still update every `reporting_duration_max`
-  - platform: copy  # Calibrated Sensor (Runs between val_unoccupied (0%) and val_occupied (100%))
-    source_id: bed_sensor_${sensor_id}
-    name: ${sensor_name} Pressure Calibrated
-    id: bed_sensor_${sensor_id}_calibrated
-    unit_of_measurement: '%'
-    entity_category: ''
-    filters:
-      - lambda: |-
-          float val_cal_top = (x - id(val_unoccupied_${sensor_id}).state) * 100;
-          float val_cal_bot = id(val_occupied_${sensor_id}).state - id(val_unoccupied_${sensor_id}).state;
-          float val_calibrated = val_cal_top/val_cal_bot;
-
-          if (val_calibrated > 100.0) {
-            val_calibrated = 100.0;
-          } else if (val_calibrated < 0.0) {
-            val_calibrated = 0.0;
-          }
-
-          return val_calibrated;
 
 number:
   - platform: template
     name: ${sensor_name} Unoccupied Pressure
     id: val_unoccupied_${sensor_id}
     icon: mdi:gauge-empty
-    unit_of_measurement: '% Raw'
+    unit_of_measurement: '%'
     entity_category: diagnostic
     optimistic: true
     restore_value: true
     initial_value: 0
-    min_value: 0
+    min_value: 0      # set to -200ish (calculate) and clamp below based on `extend_negative_range`
     max_value: 110
     step: 1.0
     mode: box
@@ -133,7 +113,7 @@ number:
     name: ${sensor_name} Occupied Pressure
     id: val_occupied_${sensor_id}
     icon: mdi:gauge-full
-    unit_of_measurement: '% Raw'
+    unit_of_measurement: '%'
     entity_category: diagnostic
     optimistic: true
     restore_value: true
@@ -158,7 +138,7 @@ number:
     step: 1.0
     mode: box
     icon: mdi:gauge
-    unit_of_measurement: '% Raw'
+    unit_of_measurement: '%'
     entity_category: config
 
 button:

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -112,6 +112,9 @@ sensor:
           float range = cal_100 - cal_0;
 
           return val/range;
+      - clamp:
+          max_value: 100
+          min_value: 0
 
 number:
   - platform: template

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -85,7 +85,7 @@ sensor:
   name: ${sensor_name} Pressure Calibrated
   id: bed_sensor_${sensor_id}_calibrated
   filters:
-    - lambda: return id(val_unoccupied_${sensor_id}).state+((x/100)*(id(val_occupied_${sensor_id}).state - id(val_unoccupied_${sensor_id})));
+    - lambda: return float(id(val_unoccupied_${sensor_id})).state+((x/100)*(id(val_occupied_${sensor_id}).state - float(id(val_unoccupied_${sensor_id}).state)));
 - platform: copy
   source_id: bed_sensor_${sensor_id}
   name: ${sensor_name} Pressure

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -85,7 +85,7 @@ sensor:
   name: ${sensor_name} Pressure Calibrated
   id: bed_sensor_${sensor_id}_calibrated
   filters:
-    - lambda: return id(val_unoccupied_${sensor_id})-((x/100)*(id(val_occupied_${sensor_id} - id(val_unoccupied_${sensor_id}))));
+    - lambda: return id(val_unoccupied_${sensor_id}).state+((x/100)*(id(val_occupied_${sensor_id}).state - id(val_unoccupied_${sensor_id})));
 - platform: copy
   source_id: bed_sensor_${sensor_id}
   name: ${sensor_name} Pressure

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -122,7 +122,7 @@ number:
     initial_value: 0
     min_value: 0
     max_value: 110
-    step: 0.1
+    step: 1.0
     on_value:
       then:
         - lambda: |-  # Update status and trigger
@@ -139,7 +139,7 @@ number:
     initial_value: 100
     min_value: 0
     max_value: 110
-    step: 0.1
+    step: 1.0
     on_value:
       then:
         - lambda: |-  # Update status and trigger
@@ -153,7 +153,7 @@ number:
     initial_value: 50
     min_value: 0
     max_value: 110
-    step: 0.1
+    step: 1.0
     icon: mdi:gauge
     unit_of_measurement: '% Raw'
     entity_category: config
@@ -168,7 +168,8 @@ button:
       then:
         - number.set:
             id: val_unoccupied_${sensor_id}
-            value: !lambda return id(bed_sensor_${sensor_id}).state;
+                                # round to 2 decimal places
+            value: !lambda return round(id(bed_sensor_${sensor_id}).state * 100)/100.0;
   - platform: template
     name: Calibrate ${sensor_name} Occupied
     id: calibration_${sensor_id}_set_occupied
@@ -178,7 +179,8 @@ button:
       then:
         - number.set:
             id: val_occupied_${sensor_id}
-            value: !lambda return id(bed_sensor_${sensor_id}).state;
+                                # round to 2 decimal places
+            value: !lambda return round(id(bed_sensor_${sensor_id}).state * 100)/100.0;
 
 script:
   - id: update_trigger_${sensor_id}

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -33,6 +33,20 @@ substitutions:
   # The max amount of time between sensor reports (even if the value hasn't changed)
   reporting_duration_max: '180s'
 
+  # Window Averaging Samples
+  # Add a sliding window moving average to the incoming sensor samples. This specifies the number of samples to
+  # average over. Each sample is 1/2 second.
+  #     - 1   Don't perform averaging (default)
+  #     - 2   Average over 2 samples (1 second)
+  #     - 10  Average over 10 samples (5 seconds)
+  averaging_window_samples: '1'
+
+  # Linear Calibration Points
+  # Change the linear calibration points for the FSR sensor. These values correspond with the raw pulses per
+  # minute from the pulse_counter. Only mess with this if you know what you're doing.
+  calibrate_linear_100: '408000'
+  calibrate_linear_0: '276000'
+
 binary_sensor:
 - platform: template
   name: Bed Occupied ${sensor_name} (Fast)
@@ -53,57 +67,32 @@ binary_sensor:
   - delayed_on_off: ${standard_delayed_on_off}  # ensure stability
   lambda: return id(bed_sensor_${sensor_id}).state > id(val_trigger_${sensor_id}).state;
 
-- platform: template
-  name: Bed Occupied ${sensor_name} (Averaged)
-  id: bed_occupied_${sensor_id}_averaged
-  device_class: occupancy
-  icon: mdi:bed
-  lambda: return id(bed_sensor_${sensor_id}_averaged).state > id(val_trigger_${sensor_id}).state;
-
 sensor:
-- platform: pulse_counter
+- platform: pulse_counter   # Raw Sensor
   pin: ${sensor_gpio}
-  name: ${sensor_name} Pressure Raw
-  id: bed_sensor_${sensor_id}_raw
+  name: ${sensor_name} Pressure
+  id: bed_sensor_${sensor_id}
   disabled_by_default: true
   update_interval: 0.5s
   unit_of_measurement: '%'
+  entity_category: diagnostic
   icon: mdi:gauge
   filters:
   - calibrate_linear:             # scale pulses/minute to 0->100%
       method: least_squares
       datapoints:
-        - 408000 -> 100.0         # 6800Hz (sensor shorted/0ohms)
-        - 276000 -> 0.0           # 4600Hz (breakforce/10k)
-  - clamp:
-  #     max_value: 100.0
-      min_value: 0.0
-  # - or:
-  #   - delta: ${reporting_delta}           # only send if sensor changes by `reporting_delta` (eliminate sensor noise)
-  #   - throttle: ${reporting_duration_max} # but still update every `reporting_duration_max`
-- platform: copy
-  source_id: bed_sensor_${sensor_id}_raw
-  name: ${sensor_name} Pressure
-  id: bed_sensor_${sensor_id}
-  filters:
-    # - lambda: return x;
-    - or:
-      - delta: ${reporting_delta}           # only send if sensor changes by `reporting_delta` (eliminate sensor noise)
-      - throttle: ${reporting_duration_max} # but still update every `reporting_duration_max`
-- platform: copy
-  source_id: bed_sensor_${sensor_id}_raw
-  name: ${sensor_name} Pressure Averaged
-  id: bed_sensor_${sensor_id}_averaged
-  filters:
-    # - lambda: return x;
+        - ${calibrate_linear_100} -> 100.0         # 6800Hz (sensor shorted/0ohms)
+        - ${calibrate_linear_0} -> 0.0           # 4600Hz (breakforce/10k)
     - sliding_window_moving_average:
-        window_size: 10
+        window_size: ${averaging_window_samples}
         send_every: 1
-    - or:
-      - delta: ${reporting_delta}           # only send if sensor changes by `reporting_delta` (eliminate sensor noise)
-      - throttle: ${reporting_duration_max} # but still update every `reporting_duration_max`
-- platform: copy
-  source_id: bed_sensor_${sensor_id}_averaged
+  - clamp:
+      min_value: 0.0
+  - or:
+    - delta: ${reporting_delta}           # only send if sensor changes by `reporting_delta` (eliminate sensor noise)
+    - throttle: ${reporting_duration_max} # but still update every `reporting_duration_max`
+- platform: copy  # Calibrated Sensor (Runs between val_unoccupied (0%) and val_occupied (100%))
+  source_id: bed_sensor_${sensor_id}
   name: ${sensor_name} Pressure Calibrated
   id: bed_sensor_${sensor_id}_calibrated
   filters:
@@ -131,7 +120,7 @@ number:
   restore_value: true
   initial_value: 0
   min_value: 0
-  max_value: 100
+  max_value: 110
   step: 0.1
   on_value:
     then:
@@ -148,7 +137,7 @@ number:
   restore_value: true
   initial_value: 100
   min_value: 0
-  max_value: 100
+  max_value: 110
   step: 0.1
   on_value:
     then:
@@ -162,7 +151,7 @@ number:
   restore_value: true
   initial_value: 50
   min_value: 0
-  max_value: 100
+  max_value: 110
   step: 0.1
   icon: mdi:gauge
   unit_of_measurement: '%'

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -109,7 +109,7 @@ sensor:
           float cal_100 = id(val_occupied_${sensor_id}).state;
 
           float val = (x - cal_0) * 100;
-          float range = cal100 - cal_0;
+          float range = cal_100 - cal_0;
 
           return val/range;
 

--- a/static/bed-presence-mk1/release.md
+++ b/static/bed-presence-mk1/release.md
@@ -9,5 +9,35 @@ breadcrumb_list:
       url: /bed-presence-mk1
 ---
 
+## 2024.10.0
+This is the first firmware update for Bed Presence Mk1. It will be available OTA to managed devices. Devices already imported into the ESPHome Dashboard will need to be recompiled to get access to the new features.
+
+**Eliminate DB Bloat** - The default delta threshold and reporting interval have been updated so that the sensor only reports new values when something actually changes. This will decrease the update frequency dramatically and eliminate bloating the database.
+
+**Improved Sensor Response** - The sensor now uses a window average by default. This helps smooth out any quick movements, while also slightly improving the response time for getting out of bed.
+
+**Calibrated Sensor** - If you're annoyed by a different response from each side of your bed, the `Calibrated Sensor` is for you. This is an additional sensor that scales your raw pressure values between the `Unoccupied Pressure` and `Occupied Pressure`.
+
+**Option to Use Full Range** - By default, Pressure [Right/Left] is focused on the most sensitive zone of the pressure sensor (Full Range = Off). This should perform well for most setups. By turning on Full Range, you can expand it to use the full range of the sensor. Consider turning ON Full Range if slight movements in bed quickly drop the sensor value to zero, causing frequent false negatives.
+
+**Lots of Customization** - If you import the device into the ESPHome Dashboard, there are now lots more substitutions within the package to customize behavior.
+
+See <a href="https://github.com/ElevatedSensors/sensor-configs/blob/main/bed-presence-mk1/sensor.yaml" target="_blank">https://github.com/ElevatedSensors/sensor-configs/blob/main/bed-presence-mk1/sensor.yaml</a> for substitution descriptions.
+
+```
+substitutions:
+- trigger_percentile: '0.75'
+- averaging_window_samples: '5'
+- fast_delayed_on: '0ms'
+- fast_delayed_off: '0ms'
+- standard_delayed_on: '0s'
+- standard_delayed_off: '1s'
+- reporting_delta: '1.0'
+- reporting_interval_max: '180s'
+- calibrate_100: '408000'
+- calibrate_0: '276000'
+```
+
 ## 2024.9.0
 - Initial Release
+

--- a/static/bed-presence-mk1/release.md
+++ b/static/bed-presence-mk1/release.md
@@ -18,6 +18,8 @@ This is the first firmware update for Bed Presence Mk1. It will be available OTA
 
 **Calibrated Sensor** - If you're annoyed by a different response from each side of your bed, the `Calibrated Sensor` is for you. This is an additional sensor that scales your raw pressure values between the `Unoccupied Pressure` and `Occupied Pressure`.
 
+**Status Sensor** - Added a binary status sensor to expose the device's connectivity state.
+
 **Option to Use Full Range** - By default, Pressure [Right/Left] is focused on the most sensitive zone of the pressure sensor (Full Range = Off). This should perform well for most setups. By turning on Full Range, you can expand it to use the full range of the sensor. Consider turning ON Full Range if slight movements in bed quickly drop the sensor value to zero, causing frequent false negatives.
 
 **Lots of Customization** - If you import the device into the ESPHome Dashboard, there are now lots more substitutions within the package to customize behavior.

--- a/static/bed-presence-mk1/sensors.md
+++ b/static/bed-presence-mk1/sensors.md
@@ -18,8 +18,9 @@ Learn about the details of each sensor and what they mean.
 | `Bed Occupied [Right/Left]` | Binary (Occupancy) [Detected/Clear]   | The primary sensor that indicates whether this side of the bed is occupied (**Detected**) or not (**Clear**). This sensor is slightly delayed to ensure stability and should be sufficient for most automations. |
 | `Bed Occupied Both`         | Binary (Occupancy) [Detected/Clear]   | Indicates if **Both** sides of the bed are occupied or not. |
 | `Bed Occupied Either`       | Binary (Occupancy) [Detected/Clear]   | Indicates if **Either** side of the bed is occupied or not. |
-| `(Fast) Sensors`            | Binary (Occupancy) [Detected/Clear]   | A copy of the primary occupancy sensors (Right/Left/Both/Either), with less delay. If you need quick response when getting into or out of bed, and can tolerate an increased chance of false negatives, use this sensor. `These sensors are disabled by default and must be manually enabled in the Home Assistant UI.` |
-| `Pressure [Right/Left]`     | Number (Pressure&nbsp;%) [0%&nbsp;-&nbsp;100%] | Indicates the current pressure reading. This value ranges from 0% to 100%, indicating the full range of the sensor. Do not worry if your unoccupied pressure reading is not 0%, or even if both sides of the bed are not similar. Some beds may swing from 0% (Unoccupied) to 95% (Occupied), while others may start at 70% and only increase to 75%. The important thing is that there is a measureable difference between the bed being occupied and unoccupied. |
+| `(Fast) Sensors`            | Binary (Occupancy) [Detected/Clear]   | A copy of the primary occupancy sensors (Right/Left/Both/Either), with less delay. If you need quick response when getting out of bed, and can tolerate an increased chance of false negatives, use this sensor. `These sensors are disabled by default and must be manually enabled in the Home Assistant UI.` |
+| `Pressure [Right/Left]`     | Number (Pressure&nbsp;%) [0%&nbsp;-&nbsp;100%] | Indicates the current pressure reading. This value ranges from 0% to 100%, indicating the selected range of the sensor (see `Full Range`). Do not worry if your unoccupied pressure reading is not 0%, or even if both sides of the bed are not similar. Some beds may swing from 0% (Unoccupied) to 95% (Occupied), while others may start at 70% and only increase to 75%. The important thing is that there is a measureable difference between the bed being occupied and unoccupied. |
+| `Calibrated Pressure [Right/Left]`     | Number (Pressure&nbsp;%) [0%&nbsp;-&nbsp;100%] | Indicates the current calibrated pressure reading. This value ranges from 0% to 100%, but only between the `Unoccupied Pressure` (0%) and `Occupied Pressure` (100%). |
 
 ## Values
 
@@ -29,9 +30,10 @@ Learn about the details of each sensor and what they mean.
 | `[Right/Left] Unoccupied Pressure` | Number (Pressure&nbsp;%) [0%&nbsp;-&nbsp;100%] | Indicates the sensor value when the bed is unoccupied. Used for calculating the ideal `[Right/Left] Trigger Pressure`. The calibration process will set this value, but it can also be adjust manually. |
 | `[Right/Left] Occupied Pressure`   | Number (Pressure&nbsp;%) [0%&nbsp;-&nbsp;100%] | Indicates the sensor value when the bed is occupied. Used for calculating the ideal `[Right/Left] Trigger Pressure`. The calibration process will set this value, but it can also be adjusted manually. |
 
-## Calibration
+## Configuration
 
-| Method Name                         | Details                                                                                   |
+| Method/Switch Name                  | Details                                                                                   |
 |-------------------------------------|-------------------------------------------------------------------------------------------|
 | `Calibrate [Right/Left] Unoccupied` | Sets the `[Right/Left] Unoccupied Pressure` using the value from `[Right/Left] Pressure`. |
 | `Calibrate [Right/Left] Occupied`   | Sets the `[Right/Left] Occupied Pressure` using the value from `[Right/Left] Pressure`.   |
+| `Full Range`                        | By default, `Pressure [Right/Left]` is focused on the most sensitive zone of the pressure sensor (`Full Range` = Off). This should perform well for most setups. By turning on `Full Range`, you can expand it to use the full range of the sensor. `Consider turning ON Full Range if slight movements in bed quickly drop the sensor value to zero, causing frequent false negatives`. |


### PR DESCRIPTION
# Eliminate DB bloat, improve sensor response, add lots of options for customization.
This is the first firmware update for Bed Presence Mk1. It will be the `2024.10.0` release and be available OTA to managed devices. Devices already imported into the ESPHome Dashboard will need to be recompiled to get access to the new features.

Closes #24 

## Eliminate DB Bloat
The default delta threshold and reporting interval have been updated so that the sensor only reports new values when something actually changes. This will decrease the update frequency dramatically and eliminate bloating the database.

## Improved Sensor Response
The sensor now uses a window average by default. This helps smooth out any quick movements, while also slightly improving the response time for getting out of bed.

## Calibrated Sensor
If you're annoyed by a different response from each side of your bed, the `Calibrated Sensor` is for you. This is an additional sensor that scales your raw pressure values between the `Unoccupied Pressure` and `Occupied Pressure`.

## Status Sensor
Added a binary status sensor to expose the device's connectivity state.

## Option to Use Full Range
By default, Pressure [Right/Left] is focused on the most sensitive zone of the pressure sensor (Full Range = Off). This should perform well for most setups. By turning on Full Range, you can expand it to use the full range of the sensor. Consider turning ON Full Range if slight movements in bed quickly drop the sensor value to zero, causing frequent false negatives.

## Lots of Customization
If you import the device into the ESPHome Dashboard, there are now lots more substitutions within the package to customize behavior.

See https://github.com/ElevatedSensors/sensor-configs/blob/main/bed-presence-mk1/sensor.yaml for substitution descriptions.

substitutions:
- trigger_percentile: '0.75'
- averaging_window_samples: '5'
- fast_delayed_on: '0ms'
- fast_delayed_off: '0ms'
- standard_delayed_on: '0s'
- standard_delayed_off: '1s'
- reporting_delta: '1.0'
- reporting_interval_max: '180s'
- calibrate_100: '408000'
- calibrate_0: '276000'