### PR TITLE
Fix Calibration Cap

### DIFF
--- a/.github/workflows/action-build-and-publish.yml
+++ b/.github/workflows/action-build-and-publish.yml
@@ -55,10 +55,6 @@ jobs:
         file: ${{ fromJson(needs.prepare.outputs.files) }}
     steps:
       - uses: actions/checkout@v4.1.7
-      - name: Replace package_import_url branch
-        run: |
-          branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
-          sed -i "s/@main/@$branch/g" ${{ matrix.file }}
       - uses: esphome/build-action@v4.0.1
         id: esphome-build
         with:

--- a/.github/workflows/action-build-and-publish.yml
+++ b/.github/workflows/action-build-and-publish.yml
@@ -55,6 +55,10 @@ jobs:
         file: ${{ fromJson(needs.prepare.outputs.files) }}
     steps:
       - uses: actions/checkout@v4.1.7
+      - name: Replace package_import_url branch
+        run: |
+          branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
+          sed -i "s/@main/@$branch/g" ${{ matrix.file }}
       - uses: esphome/build-action@v4.0.1
         id: esphome-build
         with:

--- a/.github/workflows/workflow-ci.yml
+++ b/.github/workflows/workflow-ci.yml
@@ -2,11 +2,11 @@ name: CI
 
 on:
   pull_request:
-  push:
-    branches-ignore:
-      - 'main'
-      - 'dependabot/**'
-      - 'gh-pages'
+  # push:
+  #   branches-ignore:
+  #     - 'main'
+  #     - 'dependabot/**'
+  #     - 'gh-pages'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/workflow-ci.yml
+++ b/.github/workflows/workflow-ci.yml
@@ -20,11 +20,11 @@ jobs:
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4.1.7
-      - name: Replace package_import_url branch to current dev branch
+      - name: Change remote_package branch to current dev branch
         run: |
           branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
-          echo "Replacing @main with @${branch} in ${{ matrix.file }}"
-          sed -i "s/@main/@${branch}/g" ${{ matrix.file }}
+          echo "Replacing @main with @${branch} in bed-presence-mk1.yaml"
+          sed -i "s/ref: main/ref: ${branch}/g" ./bed-presence-mk1.yaml
       - name: Build ESPHome firmware to verify configuration
         uses: esphome/build-action@v4.0.1
         id: esphome-build

--- a/.github/workflows/workflow-ci.yml
+++ b/.github/workflows/workflow-ci.yml
@@ -20,6 +20,11 @@ jobs:
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4.1.7
+      - name: Replace package_import_url branch to current dev branch
+        run: |
+          branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
+          echo ${branch}
+          sed -i "s/@main/@${branch}/g" ./*factory.yaml
       - name: Build ESPHome firmware to verify configuration
         uses: esphome/build-action@v4.0.1
         id: esphome-build

--- a/.github/workflows/workflow-ci.yml
+++ b/.github/workflows/workflow-ci.yml
@@ -23,8 +23,9 @@ jobs:
       - name: Replace package_import_url branch to current dev branch
         run: |
           branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
-          echo ${branch}
-          sed -i "s/@main/@${branch}/g" ./*factory.yaml
+          echo "Replacing @main with ${branch} in ${{ matrix.file }}"
+          sed -i "s/@main/@${branch}/g" ${{ matrix.file }}
+          cat ${{ matrix.file }}
       - name: Build ESPHome firmware to verify configuration
         uses: esphome/build-action@v4.0.1
         id: esphome-build

--- a/.github/workflows/workflow-ci.yml
+++ b/.github/workflows/workflow-ci.yml
@@ -23,9 +23,8 @@ jobs:
       - name: Replace package_import_url branch to current dev branch
         run: |
           branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
-          echo "Replacing @main with ${branch} in ${{ matrix.file }}"
+          echo "Replacing @main with @${branch} in ${{ matrix.file }}"
           sed -i "s/@main/@${branch}/g" ${{ matrix.file }}
-          cat ${{ matrix.file }}
       - name: Build ESPHome firmware to verify configuration
         uses: esphome/build-action@v4.0.1
         id: esphome-build

--- a/.github/workflows/workflow-ci.yml
+++ b/.github/workflows/workflow-ci.yml
@@ -2,11 +2,11 @@ name: CI
 
 on:
   pull_request:
-  # push:
-  #   branches-ignore:
-  #     - 'main'
-  #     - 'dependabot/**'
-  #     - 'gh-pages'
+  push:
+    branches-ignore:
+      - 'main'
+      - 'dependabot/**'
+      - 'gh-pages'
   workflow_dispatch:
 
 jobs:

--- a/bed-presence-mk1.factory.yaml
+++ b/bed-presence-mk1.factory.yaml
@@ -4,7 +4,7 @@ packages:
 esphome:
   project:
     name: ElevatedSensors.BedPresenceMk1
-    version: 2024.10.0
+    version: 2025.2.0
 
 # Allow ESPHome Adoption
 dashboard_import:

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -125,7 +125,7 @@ number:
     restore_value: true
     initial_value: 0
     min_value: 0
-    max_value: 110
+    max_value: 120
     step: 1.0
     mode: box
     on_value:
@@ -142,7 +142,7 @@ number:
     restore_value: true
     initial_value: 100
     min_value: 0
-    max_value: 110
+    max_value: 120
     step: 1.0
     mode: box
     on_value:
@@ -156,7 +156,7 @@ number:
     restore_value: true
     initial_value: 50
     min_value: 0
-    max_value: 110
+    max_value: 120
     step: 1.0
     mode: box
     icon: mdi:gauge

--- a/static/bed-presence-mk1/release.md
+++ b/static/bed-presence-mk1/release.md
@@ -10,7 +10,7 @@ breadcrumb_list:
 ---
 
 ## 2025.2.0
-**Fixed Calibration Cap**: Accomodate the increased sensitivity of revC boards, ensuring accurate pressure calibration up to
+**Fix Calibration Cap**: Accomodate the increased sensitivity of revC boards, ensuring accurate pressure calibration up to
 120% instead of being limited to 110%.
 
 ## 2024.10.0

--- a/static/bed-presence-mk1/release.md
+++ b/static/bed-presence-mk1/release.md
@@ -9,20 +9,34 @@ breadcrumb_list:
       url: /bed-presence-mk1
 ---
 
+## 2025.2.0
+**Fixed Calibration Cap**: Accomodate the increased sensitivity of revC boards, ensuring accurate pressure calibration up to
+120% instead of being limited to 110%.
+
 ## 2024.10.0
-This is the first firmware update for Bed Presence Mk1. It will be available OTA to managed devices. Devices already imported into the ESPHome Dashboard will need to be recompiled to get access to the new features.
+This is the first firmware update for Bed Presence Mk1. It will be available OTA to managed devices. Devices already
+imported into the ESPHome Dashboard will need to be recompiled to get access to the new features.
 
-**Eliminate DB Bloat** - The default delta threshold and reporting interval have been updated so that the sensor only reports new values when something actually changes. This will decrease the update frequency dramatically and eliminate bloating the database.
+**Eliminate DB Bloat** - The default delta threshold and reporting interval have been updated so that the sensor only
+reports new values when something actually changes. This will decrease the update frequency dramatically and eliminate
+bloating the database.
 
-**Improved Sensor Response** - The sensor now uses a window average by default. This helps smooth out any quick movements, while also slightly improving the response time for getting out of bed.
+**Improved Sensor Response** - The sensor now uses a window average by default. This helps smooth out any quick movements,
+while also slightly improving the response time for getting out of bed.
 
-**Calibrated Sensor** - If you're annoyed by a different response from each side of your bed, the `Calibrated Sensor` is for you. This is an additional sensor that scales your raw pressure values between the `Unoccupied Pressure` and `Occupied Pressure`.
+**Calibrated Sensor** - If you're annoyed by a different response from each side of your bed, the `Calibrated Sensor` is for
+you. This is an additional sensor that scales your raw pressure values between the `Unoccupied Pressure` and `Occupied
+Pressure`.
 
 **Status Sensor** - Added a binary status sensor to expose the device's connectivity state.
 
-**Option to Use Full Range** - By default, Pressure [Right/Left] is focused on the most sensitive zone of the pressure sensor (Full Range = Off). This should perform well for most setups. By turning on Full Range, you can expand it to use the full range of the sensor. Consider turning ON Full Range if slight movements in bed quickly drop the sensor value to zero, causing frequent false negatives.
+**Option to Use Full Range** - By default, Pressure [Right/Left] is focused on the most sensitive zone of the pressure
+sensor (Full Range = Off). This should perform well for most setups. By turning on Full Range, you can expand it to use
+the full range of the sensor. Consider turning ON Full Range if slight movements in bed quickly drop the sensor value to
+zero, causing frequent false negatives.
 
-**Lots of Customization** - If you import the device into the ESPHome Dashboard, there are now lots more substitutions within the package to customize behavior.
+**Lots of Customization** - If you import the device into the ESPHome Dashboard, there are now lots more substitutions
+within the package to customize behavior.
 
 See <a href="https://github.com/ElevatedSensors/sensor-configs/blob/main/bed-presence-mk1/sensor.yaml" target="_blank">https://github.com/ElevatedSensors/sensor-configs/blob/main/bed-presence-mk1/sensor.yaml</a> for substitution descriptions.
 


### PR DESCRIPTION
**Fix Calibration Cap**: Accomodate the increased sensitivity of revC boards, ensuring accurate pressure calibration up to
120% instead of being limited to 110%.
**Increase Version to 2025.2.0**

Closes #35 