### PR TITLE
fix: Only stop BLE scanning when the last API client disconnects

### DIFF
--- a/esphome-common/bluetooth-proxy.yaml
+++ b/esphome-common/bluetooth-proxy.yaml
@@ -3,7 +3,12 @@ api:
     - esp32_ble_tracker.start_scan:
         continuous: true
   on_client_disconnected:
-    - esp32_ble_tracker.stop_scan:
+    if:
+      condition:
+        not:
+          api.connected:
+      then:
+        - esp32_ble_tracker.stop_scan:
 
 bluetooth_proxy:
   active: true


### PR DESCRIPTION
This PR makes it so that the BLE scanning isn't stopped whenever any API client disconnects, but only when the _last_ API client disconnects. 

This fixes the edge case where a second API client connecting and disconnecting would stop the BLE scanning until another API client would connect.