### PR TITLE
Add toggle for BT scanning mode

### DIFF
--- a/bed-presence-mk1.factory.yaml
+++ b/bed-presence-mk1.factory.yaml
@@ -4,7 +4,7 @@ packages:
 esphome:
   project:
     name: ElevatedSensors.BedPresenceMk1
-    version: 2025.6.1
+    version: 2025.6.2
 
 # Allow ESPHome Adoption
 dashboard_import:

--- a/esphome-common/bluetooth-proxy.yaml
+++ b/esphome-common/bluetooth-proxy.yaml
@@ -11,10 +11,29 @@ api:
         - esp32_ble_tracker.stop_scan:
 
 bluetooth_proxy:
+  id: bt_proxy
   active: true
 
 esp32_ble_tracker:
   id: ble_tracker
   scan_parameters:
-    active: true
+    active: false
     continuous: false
+
+select:
+  - platform: template
+    name: Bluetooth Scanner Mode
+    id: scanner_mode
+    options:
+      - "Passive"
+      - "Active"
+    lambda: |-
+      if (id(ble_tracker).get_scan_active()) {
+        return {"Active"};
+      } else {
+        return {"Passive"};
+      }
+    set_action:
+      - lambda: |-
+          id(bt_proxy).bluetooth_scanner_set_mode(x == "Active");
+      - component.update: scanner_mode

--- a/esphome-common/bluetooth-proxy.yaml
+++ b/esphome-common/bluetooth-proxy.yaml
@@ -24,6 +24,8 @@ select:
   - platform: template
     name: Bluetooth Scanner Mode
     id: scanner_mode
+    entity_category: config
+    icon: mdi:bluetooth
     options:
       - "Passive"
       - "Active"


### PR DESCRIPTION
Patch to fw version 2025.6.x. Bluetooth Proxy support was added, but active scanning leads to excess drain on Bluetooth sensor batteries. This update defaults the BT Proxy's scanning mode to `Passive`, and provides a toggle to switch between `Passive` and `Active`.

Fix #63 