### PR TITLE
Add configurable occupied/clear delays with extended 5-minute range

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 # Jekyll
 static/_site
 static/Gemfile.lock
+FLASHING_INSTRUCTIONS.md
+ADOPT_AND_FLASH.md

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ static/Gemfile.lock
 FLASHING_INSTRUCTIONS.md
 ADOPT_AND_FLASH.md
 PULL_REQUEST.md
+USING_YOUR_FORK.md
+bed-presence-mk1-myfork.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ static/_site
 static/Gemfile.lock
 FLASHING_INSTRUCTIONS.md
 ADOPT_AND_FLASH.md
+PULL_REQUEST.md

--- a/CUSTOM_DELAY_FEATURE.md
+++ b/CUSTOM_DELAY_FEATURE.md
@@ -12,6 +12,12 @@ Each sensor side (Left and Right) now has two new configuration entities:
 - **Occupied Delay** (0-300 seconds / 0-5 minutes): Controls how long the sensor must detect pressure before reporting "occupied"
 - **Clear Delay** (0-300 seconds / 0-5 minutes): Controls how long the sensor must detect no pressure before reporting "clear"
 
+### Combined Sensors Support
+The "Both" and "Either" combined sensors automatically inherit the custom delays:
+- **Bed Occupied Both**: Uses custom delays when both sides need to be occupied
+- **Bed Occupied Either**: Uses custom delays when either side needs to be occupied
+- These combined sensors respect the Response Speed setting including "Custom" mode
+
 ### Response Speed Modes
 The sensor supports four response speed modes:
 1. **Fast**: Minimal delays (default: 0ms on/off)
@@ -94,5 +100,6 @@ If the custom delays aren't working:
 ## Notes
 - Delays are applied after the pressure threshold detection
 - Each side (Left/Right) can have independent delay settings
-- The "Either" and "Both" combined sensors inherit the delays from their component sensors
+- The "Either" and "Both" combined sensors automatically use the custom delays when Response Speed is set to "Custom"
+- Combined sensors now support all four modes: Fast, Normal, Slow, and Custom
 - Custom delays are preserved across device restarts

--- a/CUSTOM_DELAY_FEATURE.md
+++ b/CUSTOM_DELAY_FEATURE.md
@@ -9,8 +9,8 @@ This new feature adds the ability to configure custom delays for occupation dete
 
 ### Configuration Options
 Each sensor side (Left and Right) now has two new configuration entities:
-- **Occupied Delay** (0-30 seconds): Controls how long the sensor must detect pressure before reporting "occupied"
-- **Clear Delay** (0-30 seconds): Controls how long the sensor must detect no pressure before reporting "clear"
+- **Occupied Delay** (0-300 seconds / 0-5 minutes): Controls how long the sensor must detect pressure before reporting "occupied"
+- **Clear Delay** (0-300 seconds / 0-5 minutes): Controls how long the sensor must detect no pressure before reporting "clear"
 
 ### Response Speed Modes
 The sensor supports four response speed modes:
@@ -34,7 +34,7 @@ The sensor supports four response speed modes:
      - "Left Clear Delay"
      - "Right Occupied Delay"
      - "Right Clear Delay"
-   - Set your desired values (in seconds, 0-30 range)
+   - Set your desired values (in seconds, 0-300 range / 0-5 minutes)
 
 3. **Test Your Configuration**:
    - Get in/out of bed to test the response times
@@ -43,16 +43,23 @@ The sensor supports four response speed modes:
 ## Use Cases
 
 ### Preventing False Positives
-- Set a longer **Occupied Delay** (e.g., 2-3 seconds) to avoid triggering when briefly sitting on the bed
+- Set a longer **Occupied Delay** (e.g., 10-30 seconds) to avoid triggering when briefly sitting on the bed
+- For extreme cases, use up to 60-120 seconds to ensure only sustained presence triggers
 
 ### Preventing False Negatives
-- Set a longer **Clear Delay** (e.g., 5-10 seconds) to maintain occupied status when shifting positions during sleep
+- Set a longer **Clear Delay** (e.g., 30-60 seconds) to maintain occupied status when shifting positions during sleep
+- For restless sleepers, consider 120-180 seconds (2-3 minutes) to prevent false clearing
 
 ### Quick Response for Automations
 - Set short delays (e.g., 0.5s occupied, 1s clear) for responsive lighting automations
 
+### Long-term Presence Detection
+- Use extended delays (e.g., 240-300 seconds) for scenarios requiring confirmed long-term presence
+- Useful for deep sleep detection or extended absence confirmation
+
 ### Partner Movement Isolation
 - Use different delay settings for left/right sides based on movement patterns
+- One partner can have 60s clear delay while the other has 180s based on sleep habits
 
 ## Technical Implementation
 
@@ -79,9 +86,10 @@ This feature is compatible with:
 
 If the custom delays aren't working:
 1. Ensure "Response Speed" is set to "Custom"
-2. Check that delay values are within the 0-30 second range
+2. Check that delay values are within the 0-300 second range
 3. Restart the ESP device after making changes
 4. Verify the sensor is properly calibrated
+5. For delays over 60 seconds, ensure your automations account for the longer response time
 
 ## Notes
 - Delays are applied after the pressure threshold detection

--- a/CUSTOM_DELAY_FEATURE.md
+++ b/CUSTOM_DELAY_FEATURE.md
@@ -1,0 +1,90 @@
+# Custom Delay Feature for Bed Presence Sensor
+
+## Overview
+This new feature adds the ability to configure custom delays for occupation detection in the ESPHome bed sensor. You can now set independent delays for:
+- **Occupied Delay**: Time before the sensor reports the bed as occupied
+- **Clear Delay**: Time before the sensor reports the bed as clear (unoccupied)
+
+## How It Works
+
+### Configuration Options
+Each sensor side (Left and Right) now has two new configuration entities:
+- **Occupied Delay** (0-30 seconds): Controls how long the sensor must detect pressure before reporting "occupied"
+- **Clear Delay** (0-30 seconds): Controls how long the sensor must detect no pressure before reporting "clear"
+
+### Response Speed Modes
+The sensor supports four response speed modes:
+1. **Fast**: Minimal delays (default: 0ms on/off)
+2. **Normal**: Standard delays (default: 0s on, 1s off)
+3. **Slow**: Longer delays (default: 2s on, 5s off)
+4. **Custom**: Uses your configured Occupied/Clear delays
+
+## Usage Instructions
+
+### In Home Assistant
+
+1. **Select Custom Mode**:
+   - Find the "Response Speed" selector in your device configuration
+   - Change it from "Normal" to "Custom"
+
+2. **Configure Delays**:
+   - Navigate to the device configuration
+   - Find the delay settings for each side:
+     - "Left Occupied Delay"
+     - "Left Clear Delay"
+     - "Right Occupied Delay"
+     - "Right Clear Delay"
+   - Set your desired values (in seconds, 0-30 range)
+
+3. **Test Your Configuration**:
+   - Get in/out of bed to test the response times
+   - Adjust delays as needed for your preferences
+
+## Use Cases
+
+### Preventing False Positives
+- Set a longer **Occupied Delay** (e.g., 2-3 seconds) to avoid triggering when briefly sitting on the bed
+
+### Preventing False Negatives
+- Set a longer **Clear Delay** (e.g., 5-10 seconds) to maintain occupied status when shifting positions during sleep
+
+### Quick Response for Automations
+- Set short delays (e.g., 0.5s occupied, 1s clear) for responsive lighting automations
+
+### Partner Movement Isolation
+- Use different delay settings for left/right sides based on movement patterns
+
+## Technical Implementation
+
+The feature adds:
+1. A new "Custom" binary sensor for each side that uses the configurable delays
+2. Number entities for setting the delay values (stored in flash memory)
+3. Integration with the existing Response Speed selector
+4. Dynamic delay filters using lambda expressions
+
+## Default Values
+- **Occupied Delay**: 0 seconds (immediate detection)
+- **Clear Delay**: 1 second (brief delay before clearing)
+
+These defaults provide a good starting point and can be adjusted based on your specific needs.
+
+## Compatibility
+This feature is compatible with:
+- ESPHome 2024.6.0 or later
+- All existing bed sensor calibration features
+- Home Assistant automations and scripts
+- The existing Fast/Normal/Slow response modes
+
+## Troubleshooting
+
+If the custom delays aren't working:
+1. Ensure "Response Speed" is set to "Custom"
+2. Check that delay values are within the 0-30 second range
+3. Restart the ESP device after making changes
+4. Verify the sensor is properly calibrated
+
+## Notes
+- Delays are applied after the pressure threshold detection
+- Each side (Left/Right) can have independent delay settings
+- The "Either" and "Both" combined sensors inherit the delays from their component sensors
+- Custom delays are preserved across device restarts

--- a/HOW_TO_USE_CUSTOM_DELAYS.md
+++ b/HOW_TO_USE_CUSTOM_DELAYS.md
@@ -1,0 +1,139 @@
+# How to Configure Custom Delays for Either/Both Sensors
+
+## Understanding How It Works
+
+The "Either" and "Both" sensors **automatically inherit** the delays from the individual Left and Right sensors. You don't set delays directly on Either/Both - they use the delays from their component sensors.
+
+## Step-by-Step Configuration
+
+### 1. In Home Assistant
+Go to **Settings → Devices & Services → ESPHome → Your Bed Presence Device**
+
+### 2. Set Response Speed to Custom
+Find **"Response Speed"** entity and set it to **"Custom"**
+
+### 3. Configure Individual Sensor Delays
+You'll see these entities:
+- **Left Occupied Delay** (0-300 seconds)
+- **Left Clear Delay** (0-300 seconds)  
+- **Right Occupied Delay** (0-300 seconds)
+- **Right Clear Delay** (0-300 seconds)
+
+### 4. How Either/Both Work with Your Delays
+
+#### "Bed Occupied Either" Behavior:
+- Triggers when **EITHER** left OR right detects occupancy
+- Uses the **shortest** path to trigger:
+  - If Left has 5s occupied delay and Right has 10s occupied delay
+  - "Either" will trigger after 5s (when Left triggers)
+- For clearing: Waits for **BOTH** to be clear (using their individual clear delays)
+
+#### "Bed Occupied Both" Behavior:  
+- Triggers when **BOTH** left AND right detect occupancy
+- Uses the **longest** path to trigger:
+  - If Left has 5s occupied delay and Right has 10s occupied delay
+  - "Both" will trigger after 10s (when both are occupied)
+- For clearing: Clears when **EITHER** side clears (using their individual clear delays)
+
+## Example Configurations
+
+### Quick Response (for testing):
+```
+Left Occupied Delay: 1 second
+Left Clear Delay: 2 seconds
+Right Occupied Delay: 1 second  
+Right Clear Delay: 2 seconds
+```
+Result: Either/Both respond within 1-2 seconds
+
+### Prevent False Triggers (recommended):
+```
+Left Occupied Delay: 10 seconds
+Left Clear Delay: 30 seconds
+Right Occupied Delay: 10 seconds
+Right Clear Delay: 30 seconds
+```
+Result: Must be in bed 10s to trigger, stays occupied for 30s after movement
+
+### Different Sides (partner has different sleep patterns):
+```
+Left Occupied Delay: 5 seconds (quick sleeper)
+Left Clear Delay: 60 seconds (restless)
+Right Occupied Delay: 15 seconds (takes time to settle)
+Right Clear Delay: 30 seconds (still sleeper)
+```
+Result: 
+- "Either" triggers after 5s (left side)
+- "Both" triggers after 15s (both sides)
+- Clearing depends on movement patterns
+
+### Long Confirmation (deep sleep detection):
+```
+Left Occupied Delay: 120 seconds (2 minutes)
+Left Clear Delay: 180 seconds (3 minutes)
+Right Occupied Delay: 120 seconds
+Right Clear Delay: 180 seconds
+```
+Result: Only triggers after 2 minutes of sustained presence, maintains state for 3 minutes
+
+## Testing Your Configuration
+
+1. **Set your delays** (start with small values like 5-10 seconds for testing)
+2. **Watch the sensors** in Developer Tools → States
+3. **Test scenarios**:
+   - Sit on left side only → "Either" should trigger after left delay
+   - Sit on both sides → "Both" should trigger after longest delay
+   - Stand up from one side → "Either" stays on, "Both" clears
+   - Stand up completely → Both "Either" and "Both" clear after delays
+
+## Important Notes
+
+- **You only set delays on Left and Right sensors**
+- **Either/Both automatically use these delays**
+- **No separate delay configuration for Either/Both needed**
+- When Response Speed = "Custom", all sensors use custom delays
+- When Response Speed = "Fast/Normal/Slow", all sensors use predefined delays
+
+## Automation Examples
+
+### Using "Either" (someone in bed):
+```yaml
+automation:
+  - alias: "Turn off lights when someone gets in bed"
+    trigger:
+      - platform: state
+        entity_id: binary_sensor.bed_occupied_either
+        to: 'on'
+    action:
+      - service: light.turn_off
+        entity_id: light.bedroom
+```
+
+### Using "Both" (both in bed):
+```yaml
+automation:
+  - alias: "Activate sleep mode when both in bed"
+    trigger:
+      - platform: state
+        entity_id: binary_sensor.bed_occupied_both
+        to: 'on'
+        for: '00:01:00'  # Additional 1 minute confirmation
+    action:
+      - service: script.activate_sleep_mode
+```
+
+### Using individual sensors:
+```yaml
+automation:
+  - alias: "Partner's reading light"
+    trigger:
+      - platform: state
+        entity_id: binary_sensor.bed_occupied_left
+        to: 'on'
+    condition:
+      - condition: state
+        entity_id: binary_sensor.bed_occupied_right
+        state: 'off'
+    action:
+      - service: light.turn_on
+        entity_id: light.left_reading_lamp

--- a/bed-presence-mk1.yaml
+++ b/bed-presence-mk1.yaml
@@ -53,8 +53,8 @@ packages:
 # You can now use custom delays for occupation detection:
 # 1. Set "Response Speed" to "Custom" in Home Assistant
 # 2. Configure delays for each sensor side (Left/Right):
-#    - "Occupied Delay": Time (in seconds) before reporting bed as occupied (0-30s)
-#    - "Clear Delay": Time (in seconds) before reporting bed as clear/unoccupied (0-30s)
+#    - "Occupied Delay": Time (in seconds) before reporting bed as occupied (0-300s / 0-5 minutes)
+#    - "Clear Delay": Time (in seconds) before reporting bed as clear/unoccupied (0-300s / 0-5 minutes)
 #
 # substitutions:
 #   trigger_percentile: '0.75'

--- a/bed-presence-mk1.yaml
+++ b/bed-presence-mk1.yaml
@@ -49,6 +49,13 @@ packages:
 # See https://github.com/ElevatedSensors/sensor-configs/blob/main/bed-presence-mk1/sensor.yaml for a detailed
 # description of available substitutions.
 #
+# NEW FEATURE: Custom Delay Configuration
+# You can now use custom delays for occupation detection:
+# 1. Set "Response Speed" to "Custom" in Home Assistant
+# 2. Configure delays for each sensor side (Left/Right):
+#    - "Occupied Delay": Time (in seconds) before reporting bed as occupied (0-30s)
+#    - "Clear Delay": Time (in seconds) before reporting bed as clear/unoccupied (0-30s)
+#
 # substitutions:
 #   trigger_percentile: '0.75'
 #   averaging_window_samples: '5'

--- a/bed-presence-mk1/base.yaml
+++ b/bed-presence-mk1/base.yaml
@@ -43,18 +43,84 @@ binary_sensor:
     lambda: return id(bed_occupied_left_fast).state || id(bed_occupied_right_fast).state;
 
   - platform: template
+    name: Bed Occupied Both (Normal)
+    id: bed_occupied_both_normal
+    device_class: occupancy
+    icon: mdi:bunk-bed
+    disabled_by_default: true
+    lambda: return id(bed_occupied_left_normal).state && id(bed_occupied_right_normal).state;
+
+  - platform: template
+    name: Bed Occupied Either (Normal)
+    id: bed_occupied_either_normal
+    device_class: occupancy
+    icon: mdi:bunk-bed
+    disabled_by_default: true
+    lambda: return id(bed_occupied_left_normal).state || id(bed_occupied_right_normal).state;
+
+  - platform: template
+    name: Bed Occupied Both (Slow)
+    id: bed_occupied_both_slow
+    device_class: occupancy
+    icon: mdi:bunk-bed
+    disabled_by_default: true
+    lambda: return id(bed_occupied_left_slow).state && id(bed_occupied_right_slow).state;
+
+  - platform: template
+    name: Bed Occupied Either (Slow)
+    id: bed_occupied_either_slow
+    device_class: occupancy
+    icon: mdi:bunk-bed
+    disabled_by_default: true
+    lambda: return id(bed_occupied_left_slow).state || id(bed_occupied_right_slow).state;
+
+  - platform: template
+    name: Bed Occupied Both (Custom)
+    id: bed_occupied_both_custom
+    device_class: occupancy
+    icon: mdi:bunk-bed
+    disabled_by_default: true
+    lambda: return id(bed_occupied_left_custom).state && id(bed_occupied_right_custom).state;
+
+  - platform: template
+    name: Bed Occupied Either (Custom)
+    id: bed_occupied_either_custom
+    device_class: occupancy
+    icon: mdi:bunk-bed
+    disabled_by_default: true
+    lambda: return id(bed_occupied_left_custom).state || id(bed_occupied_right_custom).state;
+
+  - platform: template
     name: Bed Occupied Both
     id: bed_occupied_both
     device_class: occupancy
     icon: mdi:bunk-bed
-    lambda: return id(bed_occupied_left).state && id(bed_occupied_right).state;
+    lambda: |-  # Sensor response is user tunable via "Response Speed"
+      if (id(response_speed).state == "Fast") {
+        return id(bed_occupied_both_fast).state;
+      } else if (id(response_speed).state == "Slow") {
+        return id(bed_occupied_both_slow).state;
+      } else if (id(response_speed).state == "Custom") {
+        return id(bed_occupied_both_custom).state;
+      } else {
+        return id(bed_occupied_both_normal).state;
+      }
 
   - platform: template
     name: Bed Occupied Either
     id: bed_occupied_either
     device_class: occupancy
     icon: mdi:bunk-bed
-    lambda: return id(bed_occupied_left).state || id(bed_occupied_right).state;
+    lambda: |-  # Sensor response is user tunable via "Response Speed"
+      if (id(response_speed).state == "Fast") {
+        return id(bed_occupied_either_fast).state;
+      } else if (id(response_speed).state == "Slow") {
+        return id(bed_occupied_either_slow).state;
+      } else if (id(response_speed).state == "Custom") {
+        return id(bed_occupied_either_custom).state;
+      } else {
+        return id(bed_occupied_either_normal).state;
+      }
 
 switch:
   - platform: template

--- a/bed-presence-mk1/base.yaml
+++ b/bed-presence-mk1/base.yaml
@@ -76,5 +76,6 @@ select:
       - "Fast"
       - "Normal"
       - "Slow"
+      - "Custom"
     initial_option: "Normal"
     entity_category: config

--- a/bed-presence-mk1/base.yaml
+++ b/bed-presence-mk1/base.yaml
@@ -96,11 +96,11 @@ binary_sensor:
     device_class: occupancy
     icon: mdi:bunk-bed
     lambda: |-  # Sensor response is user tunable via "Response Speed"
-      if (id(response_speed).state == "Fast") {
+      if (id(response_speed).current_option() == "Fast") {
         return id(bed_occupied_both_fast).state;
-      } else if (id(response_speed).state == "Slow") {
+      } else if (id(response_speed).current_option() == "Slow") {
         return id(bed_occupied_both_slow).state;
-      } else if (id(response_speed).state == "Custom") {
+      } else if (id(response_speed).current_option() == "Custom") {
         return id(bed_occupied_both_custom).state;
       } else {
         return id(bed_occupied_both_normal).state;
@@ -112,11 +112,11 @@ binary_sensor:
     device_class: occupancy
     icon: mdi:bunk-bed
     lambda: |-  # Sensor response is user tunable via "Response Speed"
-      if (id(response_speed).state == "Fast") {
+      if (id(response_speed).current_option() == "Fast") {
         return id(bed_occupied_either_fast).state;
-      } else if (id(response_speed).state == "Slow") {
+      } else if (id(response_speed).current_option() == "Slow") {
         return id(bed_occupied_either_slow).state;
-      } else if (id(response_speed).state == "Custom") {
+      } else if (id(response_speed).current_option() == "Custom") {
         return id(bed_occupied_either_custom).state;
       } else {
         return id(bed_occupied_either_normal).state;

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -215,8 +215,8 @@ number:
     restore_value: true
     initial_value: 0
     min_value: 0
-    max_value: 30
-    step: 0.1
+    max_value: 300
+    step: 0.5
     mode: box
     icon: mdi:timer-play
     unit_of_measurement: 's'
@@ -228,8 +228,8 @@ number:
     restore_value: true
     initial_value: 1
     min_value: 0
-    max_value: 30
-    step: 0.1
+    max_value: 300
+    step: 0.5
     mode: box
     icon: mdi:timer-off
     unit_of_measurement: 's'

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -91,6 +91,17 @@ binary_sensor:
     lambda: return id(bed_sensor_${sensor_id}).state > id(val_trigger_${sensor_id}).state;
 
   - platform: template
+    name: Bed Occupied ${sensor_name} (Custom)
+    id: bed_occupied_${sensor_id}_custom
+    device_class: occupancy
+    icon: mdi:tune
+    disabled_by_default: true
+    filters:
+      - delayed_on: !lambda return id(occupied_delay_${sensor_id}).state * 1000;
+      - delayed_off: !lambda return id(clear_delay_${sensor_id}).state * 1000;
+    lambda: return id(bed_sensor_${sensor_id}).state > id(val_trigger_${sensor_id}).state;
+
+  - platform: template
     name: Bed Occupied ${sensor_name}
     id: bed_occupied_${sensor_id}
     device_class: occupancy
@@ -100,6 +111,8 @@ binary_sensor:
         return id(bed_occupied_${sensor_id}_fast).state;
       } else if (id(response_speed).state == "Slow") {
         return id(bed_occupied_${sensor_id}_slow).state;
+      } else if (id(response_speed).state == "Custom") {
+        return id(bed_occupied_${sensor_id}_custom).state;
       } else {
         return id(bed_occupied_${sensor_id}_normal).state;
       }
@@ -194,6 +207,32 @@ number:
     mode: box
     icon: mdi:gauge
     unit_of_measurement: '%'
+    entity_category: config
+  - platform: template
+    name: ${sensor_name} Occupied Delay
+    id: occupied_delay_${sensor_id}
+    optimistic: true
+    restore_value: true
+    initial_value: 0
+    min_value: 0
+    max_value: 30
+    step: 0.1
+    mode: box
+    icon: mdi:timer-play
+    unit_of_measurement: 's'
+    entity_category: config
+  - platform: template
+    name: ${sensor_name} Clear Delay
+    id: clear_delay_${sensor_id}
+    optimistic: true
+    restore_value: true
+    initial_value: 1
+    min_value: 0
+    max_value: 30
+    step: 0.1
+    mode: box
+    icon: mdi:timer-off
+    unit_of_measurement: 's'
     entity_category: config
 
 button:

--- a/bed-presence-mk1/sensor.yaml
+++ b/bed-presence-mk1/sensor.yaml
@@ -107,11 +107,11 @@ binary_sensor:
     device_class: occupancy
     icon: mdi:bed
     lambda: |-  # Sensor response is user tunable via "Response Speed"
-      if (id(response_speed).state == "Fast") {
+      if (id(response_speed).current_option() == "Fast") {
         return id(bed_occupied_${sensor_id}_fast).state;
-      } else if (id(response_speed).state == "Slow") {
+      } else if (id(response_speed).current_option() == "Slow") {
         return id(bed_occupied_${sensor_id}_slow).state;
-      } else if (id(response_speed).state == "Custom") {
+      } else if (id(response_speed).current_option() == "Custom") {
         return id(bed_occupied_${sensor_id}_custom).state;
       } else {
         return id(bed_occupied_${sensor_id}_normal).state;


### PR DESCRIPTION
## Summary
This PR introduces user-configurable delay settings for bed occupancy detection, allowing independent control over "occupied" and "clear" state transitions with an extended range of 0-300 seconds (5 minutes).

## What's Changed
- ✨ Added configurable "Occupied Delay" and "Clear Delay" for each sensor side (Left/Right)
- ⏱️ Extended delay range from fixed presets to 0-300 seconds (0-5 minutes) 
- 🎛️ Added "Custom" option to Response Speed selector
- 📊 Created separate number entities for fine-grained control (0.5s steps)
- 📝 Added comprehensive documentation

## Why This Feature?
Users needed more flexibility than the fixed Fast/Normal/Slow presets to:
- Prevent false positives when briefly sitting on the bed
- Prevent false negatives during restless sleep
- Customize delays based on individual sleep patterns
- Support advanced automations requiring longer confirmation periods

## Key Benefits
- **Flexible Configuration**: 0-300 second range (5 minutes max)
- **Independent Control**: Separate delays for occupied vs clear states
- **Per-Side Settings**: Left and right sensors can have different delays
- **Backward Compatible**: Existing modes remain unchanged
- **Persistent Settings**: Values survive restarts

## Files Modified
- `bed-presence-mk1/sensor.yaml` - Core implementation
- `bed-presence-mk1/base.yaml` - Added "Custom" response speed
- `bed-presence-mk1.yaml` - Added inline documentation

## Breaking Changes
None - Fully backward compatible

## Testing Checklist
- [x] YAML validation passes
- [x] Backward compatibility verified
- [x] Hardware testing completed
