### PR TITLE
Change Driver Version to "dev", update URL's

### DIFF
--- a/bed-presence-mk1.factory.yaml
+++ b/bed-presence-mk1.factory.yaml
@@ -28,7 +28,7 @@ update:
   - platform: http_request
     id: update_http_request
     name: Firmware
-    source: https://docs.elevatedsensors.com/bpmk1-manifest.json
+    source: https://github.com/ElevatedSensors/bed-presence-mk1/releases/latest/download/bed-presence-mk1.manifest.json
     update_interval: 6h
 
 http_request:

--- a/integrations/hubitat/drivers/bed-presence-mk1.groovy
+++ b/integrations/hubitat/drivers/bed-presence-mk1.groovy
@@ -8,7 +8,7 @@ metadata {
         namespace: 'elevated_sensors',
         author: 'Elevated Sensors',
         singleThreaded: true,
-        importUrl: 'https://raw.githubusercontent.com/ElevatedSensors/sensor-configs/main/integrations/hubitat/drivers/bed-presence-mk1.groovy') {
+        importUrl: 'https://github.com/ElevatedSensors/bed-presence-mk1/releases/latest/download/elevated_sensors.BedPresenceMk1.groovy') {
 
         capability 'Sensor'
         capability 'Refresh'
@@ -321,7 +321,7 @@ private double round2(final double value) {
 }
 
 private void syncDriverVersion() {
-    final String DRIVER_VERSION = "2025.6.0"
+    final String DRIVER_VERSION = "dev"
 
     final String stored = device.getDataValue("Driver Version")
     if (stored != DRIVER_VERSION) {


### PR DESCRIPTION
The version is now auto-populated during releases. Updating source urls to point to github releases for updates.